### PR TITLE
[Issue-18] Add button to copy text to clipboard

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 import React, { useEffect, useRef, useState } from "react";
 import {
   FaBrain,
+  FaClipboard,
+  FaCopy,
   FaListAlt,
   FaPlayCircle,
   FaSave,
@@ -117,6 +119,23 @@ const MacWindowHeader = () => {
       .catch(console.error);
   };
 
+  const copyElementText = (elementId: string) => {
+    const element = document.getElementById(elementId);
+    if (!element) {
+      return;
+    }
+
+    const text = element.innerText;
+    navigator.clipboard.writeText(text).then(
+      () => {
+        console.info("Copied text to clipboard");
+      },
+      () => {
+        console.error("Failed to copy text to clipboard");
+      }
+    );
+  };
+
   return (
     <div className="flex items-center gap-1 rounded-t-3xl p-3">
       <PopIn delay={0.4}>
@@ -135,6 +154,13 @@ const MacWindowHeader = () => {
       >
         <FaSave size={12} />
         <p className="font-mono">Save</p>
+      </div>
+      <div
+        className="mr-1 flex cursor-pointer items-center gap-2 rounded-full border-2 border-white/30 p-1 px-2 hover:bg-white/10"
+        onClick={(): void => copyElementText(messageListId)}
+      >
+        <FaClipboard size={12} />
+        <p className="font-mono">Copy</p>
       </div>
     </div>
   );

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useRef, useState } from "react";
 import {
   FaBrain,
   FaClipboard,
-  FaCopy,
   FaListAlt,
   FaPlayCircle,
   FaSave,


### PR DESCRIPTION
In an effort to quickly address the need noted in [issue 18](https://github.com/reworkd/AgentGPT/issues/18), I added a quick button for copying the inner text of the run to the clipboard. In this way, it can quickly be used in whatever application desired without spending a lot of effort on specific use cases at the moment.