### PR TITLE
add cd in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ git clone git@github.com:YOU_USER/AgentGPT.git
 3. Install dependencies:
 
 ```bash
+cd AgentGPT
 npm install
 ```
 


### PR DESCRIPTION
Fixes #7 

Add `cd` instruction to have the complete installation steps in the README file.