### PR TITLE
Bugfix for #68 

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -93,26 +93,20 @@ const Drawer = ({
           <DrawerItem
             icon={<FaDiscord />}
             text="Discord"
-            onClick={() =>
-              window.open("https://discord.gg/jdSBAnmdnY", "_blank")
-            }
+            href="https://discord.gg/jdSBAnmdnY"
+            target="_blank"
           />
           <DrawerItem
             icon={<FaTwitter />}
             text="Twitter"
-            onClick={() =>
-              window.open(
-                "https://twitter.com/asimdotshrestha/status/1644883727707959296",
-                "_blank"
-              )
-            }
+            href="https://twitter.com/asimdotshrestha/status/1644883727707959296"
+            target="_blank"
           />
           <DrawerItem
             icon={<FaGithub />}
             text="GitHub"
-            onClick={() =>
-              window.open("https://github.com/reworkd/AgentGPT", "_blank")
-            }
+            href="https://github.com/reworkd/AgentGPT"
+            target="_blank"
           />
         </div>
       </div>
@@ -120,7 +114,7 @@ const Drawer = ({
   );
 };
 
-interface DrawerItemProps {
+interface DrawerItemProps extends Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target'> {
   icon: React.ReactNode;
   text: string;
   border?: boolean;
@@ -128,25 +122,48 @@ interface DrawerItemProps {
   className?: string;
 }
 
-const DrawerItem = ({
-  icon,
-  text,
-  border,
-  onClick,
-  className,
-}: DrawerItemProps) => {
-  return (
-    <div
-      className={clsx(
-        "flex cursor-pointer flex-row items-center rounded-md rounded-md p-2 hover:bg-white/5",
-        border && "border-[1px] border-white/20",
-        `${className || ""}`
-      )}
-      onClick={onClick}
-    >
-      {icon}
-      <span className="text-md ml-4">{text}</span>
-    </div>
-  );
+const DrawerItem = (props: DrawerItemProps) => {
+  const {
+    icon,
+    text,
+    border,
+    href,
+    target,
+    onClick,
+    className,
+  } = props;
+
+  if ( href ) {
+    return (
+      <a
+        className={clsx(
+          "flex cursor-pointer flex-row items-center rounded-md rounded-md p-2 hover:bg-white/5",
+          border && "border-[1px] border-white/20",
+          `${className || ""}`
+        )}
+        href={href}
+        target={target ?? "_blank"}
+      >
+        {icon}
+        <span className="text-md ml-4">{text}</span>
+      </a>
+    );
+  }
+  else {
+    return (
+      <button
+        type='button'
+        className={clsx(
+          "flex cursor-pointer flex-row items-center rounded-md rounded-md p-2 hover:bg-white/5",
+          border && "border-[1px] border-white/20",
+          `${className || ""}`
+        )}
+        onClick={onClick}
+      >
+        {icon}
+        <span className="text-md ml-4">{text}</span>
+      </button>
+    );
+  }
 };
 export default Drawer;


### PR DESCRIPTION
Fixes #68 

- Isomorphic DrawerItem to be either a clickable button or anchor
- Converted DrawerItem `div` into a `button` for WCAG purposes and a11y best practices for a tabbable DOM

UIX;
![image](https://user-images.githubusercontent.com/5223310/231658207-7cfe4dfd-7aa4-45c6-a78b-d7ea52434403.png)

Tabbable works as it gets the focus style;
![image](https://user-images.githubusercontent.com/5223310/231658278-ef9c5716-1447-4bdd-84f6-87c10e5e5d2d.png)
