### PR TITLE
Fix settings dialog input overflow bug.

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -17,9 +17,9 @@ const Input = ({
   disabled,
 }: InputProps) => {
   return (
-    <div className="z-10 flex w-full items-center rounded-xl bg-[#3a3a3a] font-mono text-lg text-white/75 shadow-xl">
+    <div className="z-10 flex w-full items-stretch rounded-xl bg-[#3a3a3a] font-mono text-lg text-white/75 shadow-xl">
       {left && (
-        <div className="center flex w-1/4 items-center rounded-xl rounded-r-none border-[2px] border-r-0 border-white/10 px-5 py-2 text-lg font-semibold tracking-wider transition-all sm:py-3">
+        <div className="center flex w-1/7 sm:w-1/4 items-center rounded-xl rounded-r-none border-[2px] border-r-0 border-white/10 px-5 py-2 text-lg font-semibold tracking-wider transition-all sm:py-3">
           {left}
         </div>
       )}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -64,7 +64,7 @@ export default function SettingsDialog({
           left={
             <>
               <FaMicrochip />
-              <span className="ml-2">Model:</span>
+              <span className="ml-2 hidden sm:block">Model:</span>
             </>
           }
           placeholder={"gpt-3.5-turbo"}
@@ -76,7 +76,7 @@ export default function SettingsDialog({
           left={
             <>
               <FaKey />
-              <span className="ml-2">Key: </span>
+              <span className="ml-2 hidden sm:block">Key: </span>
             </>
           }
           placeholder={"sk-..."}


### PR DESCRIPTION
Modified the left element on settings dialog and the input element so both 'left' and the input itself are the same height.
Issue https://github.com/reworkd/AgentGPT/issues/98#issue-1667386797