### PR TITLE
fix: remove rogue zero

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -195,7 +195,7 @@ const Home: NextPage = () => {
               </Button>
             </Expand>
           </div>
-          {tasks.length && <TaskWindow tasks={tasks} />}
+          {tasks.length > 0 && <TaskWindow tasks={tasks} />}
         </div>
       </main>
     </DefaultLayout>


### PR DESCRIPTION
When a user has no tasks, instead of displaying nothing it shows "0" so I converted the check into a boolean