### PR TITLE
Fix `./setup.sh --docker` build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Use the official Node.js image as the base image
 FROM node:19-alpine
 
+ARG NODE_ENV
+
+ENV NODE_ENV=$NODE_ENV
+
 # Set the working directory
 WORKDIR /app
 

--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,8 @@ printf $ENV > .env
 
 if [ "$1" = "--docker" ]; then
   printf $ENV > .env.docker
-  docker build -t agentgpt .
+  source .env.docker
+  docker build --build-arg NODE_ENV=$NODE_ENV -t agentgpt .
   docker run -d --name agentgpt -p 3000:3000 -v $(pwd)/db:/app/db agentgpt
 else
   printf $ENV > .env


### PR DESCRIPTION
Fixes an issue with the `NODE_ENV` environment variable defaulting to `production` during the Docker build process, which was causing problems with the `./setup.sh --docker` command.

Fixes #147.