### PR TITLE
Key validation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 cd "$(dirname "$0")" || exit
 
+is_valid_key() {
+  local api_key=$1
+  local pattern="^sk-[a-zA-Z0-9]{48}$"
+  [[ $api_key =~ $pattern ]] && return 0 || return 1
+}
+
 echo -n "Enter your OpenAI Key (eg: sk...): "
 read OPENAI_API_KEY
+
+if is_valid_key $OPENAI_API_KEY; then
+  echo "Valid API key"
+else
+  echo "Invalid API key"
+  exit
+fi
 
 NEXTAUTH_SECRET=$(openssl rand -base64 32)
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 cd "$(dirname "$0")" || exit
 
-is_valid_key() {
+is_valid_sk_key() {
   local api_key=$1
   local pattern="^sk-[a-zA-Z0-9]{48}$"
   [[ $api_key =~ $pattern ]] && return 0 || return 1
 }
 
-echo -n "Enter your OpenAI Key (eg: sk...): "
+echo -n "Enter your OpenAI Key (eg: sk...) or press enter to continue with no key: "
 read OPENAI_API_KEY
 
-if is_valid_key $OPENAI_API_KEY; then
+if is_valid_sk_key $OPENAI_API_KEY || [ -z "$OPENAI_API_KEY" ]; then
   echo "Valid API key"
 else
-  echo "Invalid API key"
+  echo "Invalid API key. Please ensure that you have billing set up on your OpenAI account"
   exit
 fi
 

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -45,9 +45,19 @@ export default function SettingsDialog({
     close();
   };
 
+  function is_valid_key(key: string) {
+    const pattern = /^sk-[a-zA-Z0-9]{48}$/;
+    return pattern.test(key);
+  }
+
   const handleSave = () => {
-    setCustomApiKey(key);
-    close();
+    if (is_valid_key(key)) {
+      setCustomApiKey(key);
+      close();
+    }
+    else {
+      alert("key is invalid, please ensure that you have set up billing in your OpenAI account")
+    }
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
Added Key validation to the setup script.

The keys from open ai have 51 characters in total and are prefixed with "sk-".
So this regex captures that case ^sk-[a-zA-Z0-9]{48}$

I've also added the same check within the settingsDialog component & It won't save an API key unless it has a valid format.
It will also notify the user with an alert.
