### PR TITLE
feat: [#232] Added a bigger UI for Goal input

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -66,7 +66,7 @@ const Input = (props: InputProps) => {
     inputElement = (
       <textarea
         className={clsx(
-          "border:black delay-50 w-full h-20 rounded-xl bg-[#3a3a3a] text-sm tracking-wider outline-0 transition-all placeholder:text-white/20 hover:border-[#1E88E5]/40 focus:border-[#1E88E5] py-3 md:text-lg border-[2px] border-white/10 px-2",
+          "border:black delay-50 w-full resize-none h-20 rounded-xl bg-[#3a3a3a] text-sm tracking-wider outline-0 transition-all placeholder:text-white/20 hover:border-[#1E88E5]/40 focus:border-[#1E88E5] py-3 md:text-lg border-[2px] border-white/10 px-2",
           disabled && " cursor-not-allowed hover:border-white/10",
           left && "md:rounded-l-none"
         )}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -8,7 +8,7 @@ import type { toolTipProperties } from "./types";
 interface InputProps {
   left?: React.ReactNode;
   value: string | number;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => void;
   placeholder?: string;
   disabled?: boolean;
   setValue?: (value: string) => void;
@@ -16,7 +16,7 @@ interface InputProps {
   attributes?: { [key: string]: string | number | string[] }; // attributes specific to input type
   toolTipProperties?: toolTipProperties;
   inputRef?: React.RefObject<HTMLInputElement>;
-  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement> | React.KeyboardEvent<HTMLTextAreaElement>) => void;
 }
 
 const Input = (props: InputProps) => {
@@ -41,6 +41,10 @@ const Input = (props: InputProps) => {
     return type === "range";
   };
 
+  const isTypeTextArea = () => {
+    return type === "textarea";
+  };
+
   let inputElement;
   const options = attributes?.options;
 
@@ -56,6 +60,22 @@ const Input = (props: InputProps) => {
         options={options}
         disabled={disabled}
         onChange={setValue}
+      />
+    );
+  } else if (isTypeTextArea()) {
+    inputElement = (
+      <textarea
+        className={clsx(
+          "border:black delay-50 w-full h-20 rounded-xl bg-[#3a3a3a] text-sm tracking-wider outline-0 transition-all placeholder:text-white/20 hover:border-[#1E88E5]/40 focus:border-[#1E88E5] sm:py-3 md:text-lg border-[2px] border-white/10 px-2",
+          disabled && " cursor-not-allowed hover:border-white/10",
+          left && "md:rounded-l-none"
+        )}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        onKeyDown={onKeyDown}
+        {...attributes}
       />
     );
   } else {

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -66,7 +66,7 @@ const Input = (props: InputProps) => {
     inputElement = (
       <textarea
         className={clsx(
-          "border:black delay-50 w-full h-20 rounded-xl bg-[#3a3a3a] text-sm tracking-wider outline-0 transition-all placeholder:text-white/20 hover:border-[#1E88E5]/40 focus:border-[#1E88E5] sm:py-3 md:text-lg border-[2px] border-white/10 px-2",
+          "border:black delay-50 w-full h-20 rounded-xl bg-[#3a3a3a] text-sm tracking-wider outline-0 transition-all placeholder:text-white/20 hover:border-[#1E88E5]/40 focus:border-[#1E88E5] py-3 md:text-lg border-[2px] border-white/10 px-2",
           disabled && " cursor-not-allowed hover:border-white/10",
           left && "md:rounded-l-none"
         )}

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -9,13 +9,18 @@ interface LabelProps {
 }
 
 const Label = ({ type, left, toolTipProperties }: LabelProps) => {
+  const isTypeTextArea = () => {
+    return type === "textarea";
+  };
+  
   return (
     <Tooltip
       child={
         <div
           className={`center flex items-center rounded-xl rounded-r-none ${
             type !== "range" ? "border-r-0 border-white/10 md:border-[2px]" : ""
-          }  py-2 text-sm font-semibold tracking-wider transition-all sm:py-3 md:pl-3 md:text-lg`}
+          }  py-2 text-sm font-semibold tracking-wider transition-all sm:py-3 md:pl-3 md:text-lg 
+          ${isTypeTextArea() && 'md:h-20'}`}
         >
           {left}
         </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -103,7 +103,7 @@ const Home: NextPage = () => {
     agent.run().then(console.log).catch(console.error);
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement> | React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !disableDeployAgent) {
       handleNewGoal()
     }
@@ -218,6 +218,7 @@ const Home: NextPage = () => {
                   onChange={(e) => setGoalInput(e.target.value)}
                   onKeyDown={(e) => handleKeyPress(e)}
                   placeholder="Make the world a better place."
+                  type='textarea'
                 />
               </Expand>
             </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -104,8 +104,11 @@ const Home: NextPage = () => {
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement> | React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !disableDeployAgent) {
-      handleNewGoal()
+    if (e.key === 'Enter'&& !disableDeployAgent) {
+      if (!e.shiftKey) {
+        // Only Enter is pressed, execute the function
+        handleNewGoal();
+      }
     }
   }
 


### PR DESCRIPTION
### **Scope of change**
- Added a bigger UI for `Goal` input using the `textarea` HTML element.
- As a `textarea` is used, users can now enter goals in multiple lines by pressing the `Shift + Enter` keys to create a new line.

### **Key Files**
- Input.tsx
- Label.tsx

### Screenshots
**Larger Screens**
<img width="753" alt="Screenshot 2023-04-19 at 2 06 55 AM" src="https://user-images.githubusercontent.com/87971509/232899300-72b14b77-5f2e-4aa0-87c6-20158c73529c.png">

**Mobile**
<img width="204" alt="Screenshot 2023-04-19 at 2 06 29 AM" src="https://user-images.githubusercontent.com/87971509/232899415-f68dc3c3-2afd-4a70-a5dd-d1282c0b5c1d.png">

### **Notes**
This fixes #232