### PR TITLE
fix: fix close Modal incorrectly

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -19,10 +19,11 @@ export default function Dialog({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-40 flex items-center justify-center overflow-y-auto overflow-x-hidden bg-black/70 p-3 font-mono text-white outline-none transition-all"
-      onClick={close}
-    >
+    <div className="fixed inset-0 z-40 flex items-center justify-center overflow-y-auto overflow-x-hidden bg-black/70 p-3 font-mono text-white outline-none transition-all">
+      <div
+        className="absolute bottom-0 left-0 right-0 top-0 "
+        onClick={close}
+      />
       <div className="relative mx-auto my-6 w-auto max-w-3xl rounded-lg border-2 border-zinc-600">
         {/*content*/}
         <div


### PR DESCRIPTION
when i copy my key in the modal, i found some bug. when i mouse down in the modal and mouseup ouside the modal,the modal will close. like the video show. I fixed it in this pr.


https://user-images.githubusercontent.com/14836590/233037939-4212cd0f-9549-41d2-9e3c-fbd2eeb01325.mov



