### PR TITLE
chore: remove unnecessary annotations & add indices to prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model Account {
   user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
+  @@index([userId])
 }
 
 model Session {
@@ -33,6 +34,8 @@ model Session {
   userId       String
   expires      DateTime
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model User {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["ReferentialIntegrity"]
+  provider = "prisma-client-js"
 }
 
 datasource db {


### PR DESCRIPTION
With the current version of Prisma (4.9.0), I believe we do not need to add `ReferentialIntegrity` in previewFeatures. 

And 
![Screenshot 2023-04-21 at 23 40 47](https://user-images.githubusercontent.com/29723695/233665476-08ee4590-bf02-40bd-8bc6-826eaae75419.png)
