### PR TITLE
🐛  Catch removeChild error use semantic node instead of text node

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -258,7 +258,7 @@ const Home: NextPage = () => {
                     <span className="ml-2">Stopping</span>
                   </>
                 ) : (
-                  "Stop agent"
+                  <span>"Stop agent"</span>
                 )}
               </Button>
             </Expand>


### PR DESCRIPTION
ref: https://github.com/facebook/react/issues/11538#issuecomment-390386520

fixed: #212 

Additional Question) There's [another workaround](https://github.com/facebook/react/issues/11538#issuecomment-417504600) that if removeChild will cause error keep child node and make not crush. Is below code useful to this situation?

```javascript
if (typeof Node === 'function' && Node.prototype) {
  const originalRemoveChild = Node.prototype.removeChild;
  Node.prototype.removeChild = function(child) {
    if (child.parentNode !== this) {
      if (console) {
        console.error('Cannot remove a child from a different parent', child, this);
      }
      return child;
    }
    return originalRemoveChild.apply(this, arguments);
  }

  const originalInsertBefore = Node.prototype.insertBefore;
  Node.prototype.insertBefore = function(newNode, referenceNode) {
    if (referenceNode && referenceNode.parentNode !== this) {
      if (console) {
        console.error('Cannot insert before a reference node from a different parent', referenceNode, this);
      }
      return newNode;
    }
    return originalInsertBefore.apply(this, arguments);
  }
}
```