### PR TITLE
feat: guest mode

### DIFF
--- a/src/components/AutonomousAgent.ts
+++ b/src/components/AutonomousAgent.ts
@@ -27,6 +27,7 @@ class AutonomousAgent {
   numLoops = 0;
   session?: Session;
   _id: string;
+  isValidGuest = false;
 
   constructor(
     name: string,
@@ -34,6 +35,7 @@ class AutonomousAgent {
     renderMessage: (message: Message) => void,
     shutdown: () => void,
     modelSettings: ModelSettings,
+    isValidGuest: boolean,
     session?: Session
   ) {
     this.name = name;
@@ -43,9 +45,16 @@ class AutonomousAgent {
     this.modelSettings = modelSettings;
     this.session = session;
     this._id = v4();
+    this.isValidGuest = isValidGuest;
   }
 
   async run() {
+    if (!this.isValidGuest && !this.modelSettings.customApiKey) {
+      this.sendErrorMessage("Invalid Guest Key");
+      this.stopAgent();
+      return;
+    }
+
     this.sendGoalMessage();
     this.sendThinkingMessage();
 

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -8,6 +8,7 @@ import {
   FaExclamationCircle,
   FaSyncAlt,
   FaCoins,
+  FaCode,
 } from "react-icons/fa";
 import Dialog from "./Dialog";
 import Input from "./Input";
@@ -15,6 +16,7 @@ import { GPT_MODEL_NAMES, GPT_4 } from "../utils/constants";
 import Accordion from "./Accordion";
 import type { ModelSettings } from "../utils/types";
 import LanguageCombobox from "./LanguageCombobox";
+import { isGuestMode } from "../utils/helpers";
 
 export const SettingsDialog: React.FC<{
   show: boolean;
@@ -45,13 +47,15 @@ export const SettingsDialog: React.FC<{
   }
 
   const handleSave = () => {
-    if (!keyIsValid(settings.customApiKey)) {
-      alert(
-        t(
-          "Key is invalid, please ensure that you have set up billing in your OpenAI account!"
-        )
-      );
-      return;
+    if (!isGuestMode()) {
+      if (!keyIsValid(settings.customApiKey)) {
+        alert(
+          t(
+            "Key is invalid, please ensure that you have set up billing in your OpenAI account!"
+          )
+        );
+        return;
+      }
     }
 
     setCustomSettings(settings);
@@ -206,6 +210,19 @@ export const SettingsDialog: React.FC<{
           attributes={{ options: GPT_MODEL_NAMES }}
           disabled={disabled}
         />
+        <br className="md:inline" />
+        {isGuestMode() && (
+          <Input
+            left={
+              <>
+                <FaCode />
+                <span className="ml-2">GuestKey:</span>
+              </>
+            }
+            value={settings.guestKey}
+            onChange={(e) => updateSettings("guestKey", e.target.value)}
+          />
+        )}
         <br className="hidden md:inline" />
         <Accordion
           child={advancedSettings}

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -77,7 +77,8 @@ export const serverEnv = {
   // Rate limiter
   UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
   UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
-  RATE_LIMITER_REQUESTS_PER_MINUTE: process.env.RATE_LIMITER_REQUESTS_PER_MINUTE,
+  RATE_LIMITER_REQUESTS_PER_MINUTE:
+    process.env.RATE_LIMITER_REQUESTS_PER_MINUTE,
 };
 
 /**
@@ -97,6 +98,7 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_FF_SUB_ENABLED: stringToBoolean(),
   NEXT_PUBLIC_FF_MOCK_MODE_ENABLED: stringToBoolean(),
   NEXT_PUBLIC_VERCEL_URL: z.string().optional(),
+  NEXT_PUBLIC_GUEST_KEY: z.string().optional(),
 });
 
 /**
@@ -117,4 +119,5 @@ export const clientEnv = {
   NEXT_PUBLIC_FF_SUB_ENABLED: process.env.NEXT_PUBLIC_FF_SUB_ENABLED,
   NEXT_PUBLIC_FF_MOCK_MODE_ENABLED:
     process.env.NEXT_PUBLIC_FF_MOCK_MODE_ENABLED,
+  NEXT_PUBLIC_GUEST_KEY: process.env.NEXT_PUBLIC_GUEST_KEY ?? "",
 };

--- a/src/hooks/useGuestMode.ts
+++ b/src/hooks/useGuestMode.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+import { env } from "../env/client.mjs";
+
+export function useGuestMode(guestKey = "") {
+  const [isValidGuest, setIsValidGuest] = useState(false);
+
+  useEffect(() => {
+    const publicGuestKey = env.NEXT_PUBLIC_GUEST_KEY ?? "";
+    const keys = publicGuestKey.split(",").filter((key) => !!key);
+    const isGuestMode = keys.length > 0;
+    const isMatchedGuestKey = !!keys.find((key) => key === guestKey);
+    const isValidGuest = isGuestMode && isMatchedGuestKey;
+    setIsValidGuest(isValidGuest);
+  }, [guestKey]);
+
+  return {
+    isValidGuest,
+  };
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_MAX_LOOPS_FREE,
   GPT_35_TURBO,
 } from "../utils/constants";
+import { useGuestMode } from "./useGuestMode";
 
 const SETTINGS_KEY = "AGENTGPT_SETTINGS";
 const DEFAULT_SETTINGS: ModelSettings = {
@@ -13,6 +14,7 @@ const DEFAULT_SETTINGS: ModelSettings = {
   customTemperature: 0.9,
   customMaxLoops: DEFAULT_MAX_LOOPS_FREE,
   maxTokens: 400,
+  guestKey: "",
 };
 
 const loadSettings = () => {
@@ -47,9 +49,18 @@ const loadSettings = () => {
 
 export function useSettings() {
   const [settings, setSettings] = useState<ModelSettings>(loadSettings);
+  const { isValidGuest } = useGuestMode(settings.guestKey);
 
+  const rewriteSettings = (settings: ModelSettings) => {
+    const rewriteSettings = {
+      ...settings,
+      isValidGuest,
+    };
+
+    return rewriteSettings;
+  };
   const saveSettings = (settings: ModelSettings) => {
-    setSettings(settings);
+    setSettings(rewriteSettings(settings));
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
   };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,7 @@ import { useAgent } from "../hooks/useAgent";
 import { isEmptyOrBlank } from "../utils/whitespace";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useSettings } from "../hooks/useSettings";
+import { useGuestMode } from "../hooks/useGuestMode";
 
 const Home: NextPage = () => {
   const [t] = useTranslation();
@@ -34,6 +35,7 @@ const Home: NextPage = () => {
   const [showHelpDialog, setShowHelpDialog] = React.useState(false);
   const [showSettingsDialog, setShowSettingsDialog] = React.useState(false);
   const [hasSaved, setHasSaved] = React.useState(false);
+  const { isValidGuest } = useGuestMode(settings.guestKey);
   const agentUtils = useAgent();
 
   useEffect(() => {
@@ -77,6 +79,7 @@ const Home: NextPage = () => {
       handleAddMessage,
       () => setAgent(null),
       settings,
+      isValidGuest,
       session ?? undefined
     );
     setAgent(agent);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { env } from "../env/client.mjs";
+
 type Constructor<T> = new (...args: unknown[]) => T;
 
 /* Check whether array is of the specified type */
@@ -57,4 +59,9 @@ export const realTasksFilter = (input: string): boolean => {
     !taskCompleteRegex.test(input) &&
     !doNothingRegex.test(input)
   );
+};
+
+export const isGuestMode = () => {
+  const guestKey = env.NEXT_PUBLIC_GUEST_KEY;
+  return guestKey && guestKey.split(",").filter((key) => !!key).length > 0;
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,4 +4,5 @@ export type ModelSettings = {
   customTemperature?: number;
   customMaxLoops?: number;
   maxTokens?: number;
+  guestKey?: string;
 };


### PR DESCRIPTION
This feature is designed for scenarios that do not require back-end service login. Some users may wish to deploy their own web pages while also providing services to friends and associates without exposing their Open AI key. In such cases, a "Guest Key" can be set up for friends to use. Once this key has been set, the visitor mode is automatically enabled. Your friend must trigger the input of their own Open AI key or access code in the settings panel of their page before they can use the service.

I have made initial progress on this feature, but there may still be some details that require optimization.

The key should be in this format: `abc,qwe,123`, where each comma-separated value can be used.