### PR TITLE
📄 Add buttons to display TaskWindow on mobile

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -16,50 +16,47 @@ export interface ButtonProps {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => Promise<void> | void;
 }
 
-const Button = forwardRef(
-  (props: ButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
-    const [loading, setLoading] = useState(false);
-    const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-      if (props.loader == true) setLoading(true);
+const Button = forwardRef((props: ButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
+  const [loading, setLoading] = useState(false);
+  const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (props.loader == true) setLoading(true);
 
-      try {
-        void Promise.resolve(props.onClick?.(e)).then();
-      } catch (e) {
-        setLoading(false);
-      }
-    };
+    try {
+      void Promise.resolve(props.onClick?.(e)).then();
+    } catch (e) {
+      setLoading(false);
+    }
+  };
 
-    return (
-      <button
-        ref={ref}
-        type={props.type}
-        disabled={loading || props.disabled}
-        className={clsx(
-          "text-gray/50 relative rounded-lg border-[2px] border-white/30 px-5 py-2 font-bold transition-all sm:px-10 sm:py-3",
-          props.disabled &&
-            "cursor-not-allowed border-white/10 bg-zinc-900 text-white/30",
-          props.disabled ||
-            "mou cursor-pointer bg-[#1E88E5]/70 text-white/80 hover:border-white/80 hover:bg-[#0084f7] hover:text-white hover:shadow-2xl",
-          props.disabled || props.enabledClassName,
-          props.className
+  return (
+    <button
+      ref={ref}
+      type={props.type}
+      disabled={loading || props.disabled}
+      className={clsx(
+        "text-gray/50 relative rounded-lg border-[2px] border-white/30 px-4 py-1 font-bold transition-all sm:px-10 sm:py-3",
+        props.disabled && "cursor-not-allowed border-white/10 bg-zinc-900 text-white/30",
+        props.disabled ||
+          "mou cursor-pointer bg-[#1E88E5]/70 text-white/80 hover:border-white/80 hover:bg-[#0084f7] hover:text-white hover:shadow-2xl",
+        props.disabled || props.enabledClassName,
+        props.className
+      )}
+      onClick={onClick}
+    >
+      {props.ping ? <Ping color="white" /> : <></>}
+      <div className="flex items-center justify-center">
+        {loading ? (
+          <Loader />
+        ) : (
+          <>
+            {props.icon ? <div className="mr-2">{props.icon}</div> : null}
+            {props.children}
+          </>
         )}
-        onClick={onClick}
-      >
-        {props.ping ? <Ping color="white" /> : <></>}
-        <div className="flex items-center justify-center">
-          {loading ? (
-            <Loader />
-          ) : (
-            <>
-              {props.icon ? <div className="mr-2">{props.icon}</div> : null}
-              {props.children}
-            </>
-          )}
-        </div>
-      </button>
-    );
-  }
-);
+      </div>
+    </button>
+  );
+});
 
 Button.displayName = "Button";
 export default Button;

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -40,6 +40,7 @@ interface ChatWindowProps extends HeaderProps {
   displaySettings?: boolean; // Controls if settings are displayed at the bottom of the ChatWindow
   openSorryDialog?: () => void;
   setAgentRun?: (name: string, goal: string) => void;
+  visibleOnMobile?: boolean;
 }
 
 const messageListId = "chat-window-message-list";
@@ -55,6 +56,7 @@ const ChatWindow = ({
   displaySettings,
   openSorryDialog,
   setAgentRun,
+  visibleOnMobile,
 }: ChatWindowProps) => {
   const [t] = useTranslation();
   const [hasUserScrolled, setHasUserScrolled] = useState(false);
@@ -102,10 +104,11 @@ const ChatWindow = ({
 
   return (
     <div
-      className={
-        "border-translucent flex w-full flex-col rounded-2xl border-2 border-white/20 bg-zinc-900 text-white shadow-2xl drop-shadow-lg " +
-        (className ?? "")
-      }
+      className={clsx(
+        "border-translucent w-full flex-col rounded-2xl border-2 border-white/20 bg-zinc-900 text-white shadow-2xl drop-shadow-lg xl:flex",
+        className,
+        visibleOnMobile ? "flex" : "hidden"
+      )}
     >
       <MacWindowHeader title={title} messages={messages} onSave={onSave} />
       <div

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "next-i18next";
-import { FaClipboard, FaImage, FaSave, FaPlay, FaPause } from "react-icons/fa";
+import { FaClipboard, FaImage, FaPause, FaPlay, FaSave } from "react-icons/fa";
 import PopIn from "./motions/popin";
 import Expand from "./motions/expand";
 import * as htmlToImage from "html-to-image";
@@ -11,17 +11,17 @@ import FadeIn from "./motions/FadeIn";
 import Menu from "./Menu";
 import type { Message } from "../types/agentTypes";
 import {
-  isAction,
-  getTaskStatus,
-  MESSAGE_TYPE_GOAL,
-  MESSAGE_TYPE_THINKING,
-  MESSAGE_TYPE_SYSTEM,
-  TASK_STATUS_STARTED,
-  TASK_STATUS_EXECUTING,
-  TASK_STATUS_COMPLETED,
-  TASK_STATUS_FINAL,
   AUTOMATIC_MODE,
+  getTaskStatus,
+  isAction,
+  MESSAGE_TYPE_GOAL,
+  MESSAGE_TYPE_SYSTEM,
+  MESSAGE_TYPE_THINKING,
   PAUSE_MODE,
+  TASK_STATUS_COMPLETED,
+  TASK_STATUS_EXECUTING,
+  TASK_STATUS_FINAL,
+  TASK_STATUS_STARTED,
 } from "../types/agentTypes";
 import clsx from "clsx";
 import { getMessageContainerStyle, getTaskStatusIcon } from "./utils/helpers";
@@ -111,8 +111,7 @@ const ChatWindow = ({
       <div
         className={clsx(
           "mb-2 mr-2 ",
-          (fullscreen && "max-h-[75vh] flex-grow overflow-auto") ||
-            "window-heights"
+          (fullscreen && "max-h-[75vh] flex-grow overflow-auto") || "window-heights"
         )}
         ref={scrollRef}
         onScroll={handleScroll}
@@ -143,29 +142,19 @@ const ChatWindow = ({
               <ChatMessage
                 message={{
                   type: MESSAGE_TYPE_SYSTEM,
-                  value:
-                    "👉 " + t("CREATE_AN_AGENT_DESCRIPTION", { ns: "chat" }),
+                  value: "👉 " + t("CREATE_AN_AGENT_DESCRIPTION", { ns: "chat" }),
                 }}
               />
             </PopIn>
             <PopIn delay={1.5}>
               <div className="m-2 flex flex-col justify-between gap-2 sm:m-4 sm:flex-row">
-                <ExampleAgentButton
-                  name="PlatformerGPT 🎮"
-                  setAgentRun={setAgentRun}
-                >
+                <ExampleAgentButton name="PlatformerGPT 🎮" setAgentRun={setAgentRun}>
                   Write some code to make a platformer game.
                 </ExampleAgentButton>
-                <ExampleAgentButton
-                  name="TravelGPT 🌴"
-                  setAgentRun={setAgentRun}
-                >
+                <ExampleAgentButton name="TravelGPT 🌴" setAgentRun={setAgentRun}>
                   Plan a detailed trip to Hawaii.
                 </ExampleAgentButton>
-                <ExampleAgentButton
-                  name="ResearchGPT 📜"
-                  setAgentRun={setAgentRun}
-                >
+                <ExampleAgentButton name="ResearchGPT 📜" setAgentRun={setAgentRun}>
                   Create a comprehensive report of the Nike company
                 </ExampleAgentButton>
               </div>
@@ -174,7 +163,7 @@ const ChatWindow = ({
         )}
       </div>
       {displaySettings && (
-        <div className="flex flex-col items-center justify-center md:flex-row">
+        <div className="flex flex-row items-center justify-center">
           <SwitchContainer label="Web Search">
             <Switch
               disabled={agent !== null}
@@ -195,13 +184,7 @@ const ChatWindow = ({
   );
 };
 
-const SwitchContainer = ({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) => {
+const SwitchContainer = ({ label, children }: { label: string; children: React.ReactNode }) => {
   return (
     <div className="m-1 flex w-36 items-center justify-center gap-2 rounded-lg border-[2px] border-white/20 bg-zinc-700 px-2 py-1">
       <p className="font-mono text-sm">{label}</p>
@@ -399,12 +382,8 @@ const ChatMessage = ({ message }: { message: Message }) => {
       {message.type != MESSAGE_TYPE_SYSTEM && (
         // Avoid for system messages as they do not have an icon and will cause a weird space
         <>
-          <div className="mr-2 inline-block h-[0.9em]">
-            {getTaskStatusIcon(message, {})}
-          </div>
-          <span className="mr-2 font-bold">
-            {t(getMessagePrefix(message), { ns: "chat" })}
-          </span>
+          <div className="mr-2 inline-block h-[0.9em]">{getTaskStatusIcon(message, {})}</div>
+          <span className="mr-2 font-bold">{t(getMessagePrefix(message), { ns: "chat" })}</span>
         </>
       )}
 
@@ -459,10 +438,7 @@ const FAQ = () => {
     <p>
       <br />
       If you are facing issues, please head over to our{" "}
-      <a
-        href="https://reworkd.github.io/AgentGPT-Documentation/docs/faq"
-        className="text-sky-500"
-      >
+      <a href="https://reworkd.github.io/AgentGPT-Documentation/docs/faq" className="text-sky-500">
         FAQ
       </a>
     </p>

--- a/src/components/TaskWindow.tsx
+++ b/src/components/TaskWindow.tsx
@@ -1,16 +1,11 @@
 import React from "react";
 import FadeIn from "./motions/FadeIn";
 import Expand from "./motions/expand";
-import {
-  MESSAGE_TYPE_TASK,
-  Task,
-  TASK_STATUS_STARTED,
-} from "../types/agentTypes";
+import { MESSAGE_TYPE_TASK, Task, TASK_STATUS_STARTED } from "../types/agentTypes";
 import { getMessageContainerStyle, getTaskStatusIcon } from "./utils/helpers";
-import { useMessageStore } from "./stores";
+import { useAgentStore, useMessageStore } from "./stores";
 import { FaListAlt, FaTimesCircle } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
-import { useAgentStore } from "./stores";
 import clsx from "clsx";
 import Input from "./Input";
 import Button from "./Button";
@@ -18,6 +13,7 @@ import { v1 } from "uuid";
 
 export const TaskWindow = () => {
   const [customTask, setCustomTask] = React.useState("");
+  const agent = useAgentStore.use.agent();
   const tasks = useMessageStore.use.tasks();
   const addMessage = useMessageStore.use.addMessage();
   const [t] = useTranslation();
@@ -53,7 +49,7 @@ export const TaskWindow = () => {
           <Button
             className="font-sm px-2 py-[0] text-sm sm:px-2 sm:py-[0]"
             onClick={handleAddTask}
-            disabled={!customTask}
+            disabled={!customTask || agent == null}
           >
             Add
           </Button>
@@ -66,8 +62,7 @@ export const TaskWindow = () => {
 const Task = ({ task }: { task: Task }) => {
   const isAgentStopped = useAgentStore.use.isAgentStopped();
   const deleteTask = useMessageStore.use.deleteTask();
-  const isTaskDeletable =
-    task.taskId && !isAgentStopped && task.status === "started";
+  const isTaskDeletable = task.taskId && !isAgentStopped && task.status === "started";
 
   const handleDeleteTask = () => {
     if (isTaskDeletable) {

--- a/src/components/TaskWindow.tsx
+++ b/src/components/TaskWindow.tsx
@@ -44,7 +44,7 @@ export const TaskWindow = ({ visibleOnMobile }: TaskWindowProps) => {
       </div>
       <div className="flex h-full w-full flex-col gap-2 px-1 py-1">
         <div className="window-heights flex w-full flex-col gap-2 overflow-y-auto overflow-x-hidden pr-1">
-          <p className="p-2 text-xs text-gray-300">
+          <p className="w-full p-2 text-center text-xs text-gray-300">
             This window will display agent tasks as they are created.
           </p>
           {tasks.map((task, i) => (

--- a/src/components/TaskWindow.tsx
+++ b/src/components/TaskWindow.tsx
@@ -11,7 +11,11 @@ import Input from "./Input";
 import Button from "./Button";
 import { v1 } from "uuid";
 
-export const TaskWindow = () => {
+export interface TaskWindowProps {
+  visibleOnMobile?: boolean;
+}
+
+export const TaskWindow = ({ visibleOnMobile }: TaskWindowProps) => {
   const [customTask, setCustomTask] = React.useState("");
   const agent = useAgentStore.use.agent();
   const tasks = useMessageStore.use.tasks();
@@ -29,12 +33,20 @@ export const TaskWindow = () => {
   };
 
   return (
-    <Expand className="xl mx-2 mt-4 hidden w-[20rem] flex-col items-center rounded-2xl border-2 border-white/20 bg-zinc-900 px-1 font-mono shadow-2xl xl:flex">
-      <div className="sticky top-0 my-2 flex items-center justify-center gap-2 bg-zinc-900 p-2 text-gray-300 ">
+    <Expand
+      className={clsx(
+        "w-full flex-col items-center rounded-2xl border-2 border-white/20 bg-zinc-900 font-mono shadow-2xl xl:mx-2 xl:flex xl:w-[20rem] xl:px-1",
+        !visibleOnMobile && "hidden"
+      )}
+    >
+      <div className="sticky top-0 my-2 flex items-center justify-center gap-2 bg-zinc-900 p-2 text-gray-100 ">
         <FaListAlt /> {t("Current tasks")}
       </div>
       <div className="flex h-full w-full flex-col gap-2 px-1 py-1">
         <div className="window-heights flex w-full flex-col gap-2 overflow-y-auto overflow-x-hidden pr-1">
+          <p className="p-2 text-xs text-gray-300">
+            This window will display agent tasks as they are created.
+          </p>
           {tasks.map((task, i) => (
             <Task key={i} task={task} />
           ))}

--- a/src/pages/agent/index.tsx
+++ b/src/pages/agent/index.tsx
@@ -9,7 +9,7 @@ import { api } from "../../utils/api";
 import ChatWindow from "../../components/ChatWindow";
 import type { Message } from "../../types/agentTypes";
 import Toast from "../../components/toast";
-import { FaTrash, FaShare, FaBackspace } from "react-icons/fa";
+import { FaBackspace, FaShare, FaTrash } from "react-icons/fa";
 import { env } from "../../env/client.mjs";
 
 import { useTranslation } from "react-i18next";
@@ -50,6 +50,7 @@ const AgentPage: NextPage = () => {
         title={getAgent?.data?.name}
         className="min-h-[80vh] md:w-[80%]"
         fullscreen
+        visibleOnMobile
       />
       <div className="flex flex-row gap-2">
         <Button icon={<FaBackspace />} onClick={() => void router.push("/")}>
@@ -68,9 +69,7 @@ const AgentPage: NextPage = () => {
         <Button
           icon={<FaShare />}
           onClick={() => {
-            void window.navigator.clipboard
-              .writeText(shareLink())
-              .then(() => setShowCopied(true));
+            void window.navigator.clipboard.writeText(shareLink()).then(() => setShowCopied(true));
           }}
           enabledClassName={"bg-green-600 hover:bg-green-400"}
         >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useRef } from "react";
 import { useTranslation } from "next-i18next";
-import { type NextPage, type GetStaticProps } from "next";
+import { type GetStaticProps, type NextPage } from "next";
 import Badge from "../components/Badge";
 import DefaultLayout from "../layout/default";
 import ChatWindow from "../components/ChatWindow";
 import Drawer from "../components/Drawer";
 import Input from "../components/Input";
 import Button from "../components/Button";
-import { FaRobot, FaStar, FaPlay } from "react-icons/fa";
+import { FaPlay, FaRobot, FaStar } from "react-icons/fa";
 import PopIn from "../components/motions/popin";
 import { VscLoading } from "react-icons/vsc";
 import AutonomousAgent from "../components/AutonomousAgent";
@@ -17,14 +17,10 @@ import { SettingsDialog } from "../components/SettingsDialog";
 import { TaskWindow } from "../components/TaskWindow";
 import { useAuth } from "../hooks/useAuth";
 import type { AgentPlaybackControl, Message } from "../types/agentTypes";
+import { AGENT_PLAY, isTask } from "../types/agentTypes";
 import { useAgent } from "../hooks/useAgent";
 import { isEmptyOrBlank } from "../utils/whitespace";
-import {
-  useMessageStore,
-  useAgentStore,
-  resetAllMessageSlices,
-} from "../components/stores";
-import { isTask, AGENT_PLAY } from "../types/agentTypes";
+import { resetAllMessageSlices, useAgentStore, useMessageStore } from "../components/stores";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useSettings } from "../hooks/useSettings";
 import { findLanguage, languages } from "../utils/languages";
@@ -52,6 +48,7 @@ const Home: NextPage = () => {
   const { session, status } = useAuth();
   const [nameInput, setNameInput] = React.useState<string>("");
   const [goalInput, setGoalInput] = React.useState<string>("");
+  const [mobileVisibleWindow, setMobileVisibleWindow] = React.useState<"Chat" | "Tasks">("Chat");
   const settingsModel = useSettings();
 
   const [showHelpDialog, setShowHelpDialog] = React.useState(false);
@@ -101,9 +98,7 @@ const Home: NextPage = () => {
     addMessage(message);
   };
 
-  const handlePause = (opts: {
-    agentPlaybackControl?: AgentPlaybackControl;
-  }) => {
+  const handlePause = (opts: { agentPlaybackControl?: AgentPlaybackControl }) => {
     if (opts.agentPlaybackControl !== undefined) {
       updateIsAgentPaused(opts.agentPlaybackControl);
     }
@@ -152,9 +147,7 @@ const Home: NextPage = () => {
   };
 
   const handleKeyPress = (
-    e:
-      | React.KeyboardEvent<HTMLInputElement>
-      | React.KeyboardEvent<HTMLTextAreaElement>
+    e: React.KeyboardEvent<HTMLInputElement> | React.KeyboardEvent<HTMLTextAreaElement>
   ) => {
     // Only Enter is pressed, execute the function
     if (e.key === "Enter" && !disableDeployAgent && !e.shiftKey) {
@@ -176,11 +169,13 @@ const Home: NextPage = () => {
     </>
   );
 
+  const handleVisibleWindowClick = (visibleWindow: "Chat" | "Tasks") => {
+    // This controls whether the ChatWindow or TaskWindow is visible on mobile
+    setMobileVisibleWindow(visibleWindow);
+  };
+
   const shouldShowSave =
-    status === "authenticated" &&
-    isAgentStopped &&
-    messages.length &&
-    !hasSaved;
+    status === "authenticated" && isAgentStopped && messages.length && !hasSaved;
 
   const firstButton =
     isAgentPaused && !isAgentStopped ? (
@@ -207,23 +202,14 @@ const Home: NextPage = () => {
 
   return (
     <DefaultLayout>
-      <HelpDialog
-        show={showHelpDialog}
-        close={() => setShowHelpDialog(false)}
-      />
+      <HelpDialog show={showHelpDialog} close={() => setShowHelpDialog(false)} />
       <SettingsDialog
         customSettings={settingsModel}
         show={showSettingsDialog}
         close={() => setShowSettingsDialog(false)}
       />
-      <SorryDialog
-        show={showSorryDialog}
-        close={() => setShowSorryDialog(false)}
-      />
-      <SignInDialog
-        show={showSignInDialog}
-        close={() => setShowSignInDialog(false)}
-      />
+      <SorryDialog show={showSorryDialog} close={() => setShowSorryDialog(false)} />
+      <SignInDialog show={showSignInDialog} close={() => setShowSignInDialog(false)} />
       <main className="flex min-h-screen flex-row">
         <Drawer
           showHelp={() => setShowHelpDialog(true)}
@@ -237,17 +223,12 @@ const Home: NextPage = () => {
             id="layout"
             className="flex h-full w-full max-w-screen-xl flex-col items-center justify-between gap-1 py-2 sm:gap-3 sm:py-5 md:justify-center"
           >
-            <div
-              id="title"
-              className="relative flex flex-col items-center font-mono"
-            >
+            <div id="title" className="relative flex flex-col items-center font-mono">
               <div className="flex flex-row items-start shadow-2xl">
                 <span className="text-4xl font-bold text-[#C0C0C0] xs:text-5xl sm:text-6xl">
                   Agent
                 </span>
-                <span className="text-4xl font-bold text-white xs:text-5xl sm:text-6xl">
-                  GPT
-                </span>
+                <span className="text-4xl font-bold text-white xs:text-5xl sm:text-6xl">GPT</span>
                 <PopIn delay={0.5}>
                   <Badge>
                     {`${i18n?.t("BETA", {
@@ -266,6 +247,22 @@ const Home: NextPage = () => {
               </div>
             </div>
 
+            <div>
+              <Button
+                className="rounded-r-none py-0 text-sm sm:py-[0.25em] xl:hidden"
+                disabled={mobileVisibleWindow == "Chat"}
+                onClick={() => handleVisibleWindowClick("Chat")}
+              >
+                Chat
+              </Button>
+              <Button
+                className="rounded-l-none py-0 text-sm sm:py-[0.25em] xl:hidden"
+                disabled={mobileVisibleWindow == "Tasks"}
+                onClick={() => handleVisibleWindowClick("Tasks")}
+              >
+                Tasks
+              </Button>
+            </div>
             <Expand className="flex w-full flex-row">
               <ChatWindow
                 className="sm:mt-4"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,6 @@ const Home: NextPage = () => {
   // zustand states with state dependencies
   const addMessage = useMessageStore.use.addMessage();
   const messages = useMessageStore.use.messages();
-  const tasks = useMessageStore.use.tasks();
   const updateTaskStatus = useMessageStore.use.updateTaskStatus();
 
   const setAgent = useAgentStore.use.setAgent();
@@ -285,7 +284,7 @@ const Home: NextPage = () => {
                 openSorryDialog={() => setShowSorryDialog(true)}
                 setAgentRun={setAgentRun}
               />
-              {(agent || tasks.length > 0) && <TaskWindow />}
+              <TaskWindow />
             </Expand>
 
             <div className="flex w-full flex-col gap-2 md:m-4 ">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,7 +31,7 @@ import { env } from "../env/client.mjs";
 
 const Home: NextPage = () => {
   const { i18n } = useTranslation();
-  // zustand states with state dependencies
+  // Zustand states with state dependencies
   const addMessage = useMessageStore.use.addMessage();
   const messages = useMessageStore.use.messages();
   const updateTaskStatus = useMessageStore.use.updateTaskStatus();
@@ -264,7 +264,6 @@ const Home: NextPage = () => {
             </div>
             <Expand className="flex w-full flex-row">
               <ChatWindow
-                className="sm:mt-4"
                 messages={messages}
                 title={session?.user.subscriptionId ? proTitle : "AgentGPT"}
                 onSave={
@@ -283,8 +282,9 @@ const Home: NextPage = () => {
                 displaySettings
                 openSorryDialog={() => setShowSorryDialog(true)}
                 setAgentRun={setAgentRun}
+                visibleOnMobile={mobileVisibleWindow === "Chat"}
               />
-              <TaskWindow />
+              <TaskWindow visibleOnMobile={mobileVisibleWindow === "Tasks"} />
             </Expand>
 
             <div className="flex w-full flex-col gap-2 md:m-4 ">


### PR DESCRIPTION
## Notes
The task window currently is only visible on screen size `xl` and above. This means mobile users will be void of a decent bit of app functionality. This PR does the following:

- Make TaskWindow always visible instead of only appearing when tasks are present
- Add a button group to the top of the page when screen size is lower than `xl`
- The button group controls which window is visible. This defaults to the chat window

## Mobile
![image](https://user-images.githubusercontent.com/50181239/237007909-a963d148-9ac7-4e8d-ae9a-b8bc58d17308.png)
![image](https://user-images.githubusercontent.com/50181239/237008224-291c9911-cad6-4c39-b503-06b07d3dea32.png)

## Web (Smaller than XL)
![image](https://user-images.githubusercontent.com/50181239/237008347-81d5e3c1-4c66-47ed-bcfb-75b925293741.png)
![image](https://user-images.githubusercontent.com/50181239/237008401-b7ca56fa-b94e-401e-8a79-2d1e07438bcb.png)

