### PR TITLE
Fixed Dockerfile and entrypoint.sh to handle Windows line endings

### DIFF
--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -23,17 +23,17 @@ RUN chmod +x /usr/local/bin/wait-for-db.sh
 
 # Copy the rest of the application code
 COPY . .
+COPY entrypoint.sh /
 
 # Ensure correct line endings after these files are edited by windows
 RUN apk add --no-cache dos2unix netcat-openbsd \
-    && dos2unix /next/wait-for-db.sh \
-    && dos2unix /next/entrypoint.sh
+    && dos2unix /entrypoint.sh
 
 
 # Expose the port the app will run on
 EXPOSE 3000
 
-ENTRYPOINT ["sh", "entrypoint.sh"]
+ENTRYPOINT ["sh", "/entrypoint.sh"]
 
 # Start the application
 CMD ["npm", "run", "dev"]

--- a/next/entrypoint.sh
+++ b/next/entrypoint.sh
@@ -1,7 +1,15 @@
 #!/bin/env sh
 
+cd /next
+dos2unix wait-for-db.sh
+
 # copy .env file if not exists
 [ ! -f .env ] && [ -f .env.example ] && cp .env.example .env
+cp .env .env.temp
+dos2unix .env.temp
+cat .env.temp > .env
+rm .env.temp
+
 source .env
 
 # Ensure DB is available before running Prisma commands


### PR DESCRIPTION
The `./next:/next/` volume binding in the `docker-compose.yml` file was overwriting the _DOS2UNIX_ fix done at the image build stage. Now, the `entrypoint.sh` is moved to the `/` directory to avoid the volume binding (causing the line ending overwrite).

Also, the dos2unix fix is run in the _entrypoint.sh_ to fix the `wait-for-db.sh` and `.env` files at runtime (for the same reason).

closes #511 