### PR TITLE
feat(#747): place colour theming into tailwind config

### DIFF
--- a/next/tailwind.config.cjs
+++ b/next/tailwind.config.cjs
@@ -64,16 +64,6 @@ module.exports = {
           }
         }
       },
-      display: {
-        100: {
-          dark: "#C0C0C0",
-        },
-      },
-      body: {
-        100: {
-          dark: "#FFFFFF"
-        }
-      }
     },
   },
   plugins: [

--- a/next/tailwind.config.cjs
+++ b/next/tailwind.config.cjs
@@ -37,7 +37,7 @@ module.exports = {
             dark: "#ff9f0a",
           },
         },
-        gray: {
+        neutral: {
           100: {
             dark: "#AEAEB2",
           },

--- a/next/tailwind.config.cjs
+++ b/next/tailwind.config.cjs
@@ -37,26 +37,29 @@ module.exports = {
             dark: "#ff9f0a",
           },
         },
-        neutral: {
+        shade: {
           100: {
-            dark: "#AEAEB2",
+            dark: "#FFFFFF",
           },
           200: {
-            dark: "#7C7C80",
+            dark: "#AEAEB2",
           },
           300: {
-            dark: "#545456",
+            dark: "#7C7C80",
           },
           400: {
-            dark: "#444446",
+            dark: "#545456",
           },
           500: {
-            dark: "#363638",
+            dark: "#444446",
           },
           600: {
-            dark: "#242426",
+            dark: "#363638",
           },
           700: {
+            dark: "#242426",
+          },
+          800: {
             dark: "#18181B",
           }
         }

--- a/next/tailwind.config.cjs
+++ b/next/tailwind.config.cjs
@@ -16,8 +16,62 @@ module.exports = {
     extend: {
       boxShadow: {
         "3xl": "0 40px 70px -15px rgba(0, 0, 0, 0.40)" // Customize the shadow value according to your preferences.
+      },
+      colors: {
+        primary: {
+          main: {
+            dark: "#409CFF",
+          },
+          active: {
+            dark: "#267BD5",
+          },
+          focusVisible: {
+            dark: "#6BB3FF",
+          },
+          hover: {
+            dark: "#5c95D1",
+          },
+        },
+        secondary: {
+          main: {
+            dark: "#ff9f0a",
+          },
+        },
+        gray: {
+          100: {
+            dark: "#AEAEB2",
+          },
+          200: {
+            dark: "#7C7C80",
+          },
+          300: {
+            dark: "#545456",
+          },
+          400: {
+            dark: "#444446",
+          },
+          500: {
+            dark: "#363638",
+          },
+          600: {
+            dark: "#242426",
+          },
+          700: {
+            dark: "#18181B",
+          }
+        }
+      },
+      display: {
+        100: {
+          dark: "#C0C0C0",
+        },
+      },
+      body: {
+        100: {
+          dark: "#FFFFFF"
+        }
       }
-    }
+    },
   },
   plugins: [
     require('@tailwindcss/forms'),


### PR DESCRIPTION
Resolves #747

**Description**: 
add color theming for dark mode (see [figma](https://www.figma.com/file/hBQdHjGlnESMcHXcaPn1lM/AgentGPT?type=design&node-id=168-2&t=b7JXtYxDqGd4HViO-0) for detail - ignore coloring for light)