### PR TITLE
pkg-config: not found when `poetry install --only main`;

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -19,6 +19,7 @@ RUN poetry install --only main
 # Removing gcc
 RUN apt-get purge -y \
   gcc \
+  pkg-config \
   && rm -rf /var/lib/apt/lists/*
 
 # Copying actual application


### PR DESCRIPTION
Ref:
https://github.com/reworkd/AgentGPT/issues/848
https://github.com/reworkd/AgentGPT/issues/850