### PR TITLE
Re-adding required dependency that was removed in 'Sync repo' (30022a7)

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.11-slim-buster as prod
 
 RUN apt-get update && apt-get install -y \
   default-libmysqlclient-dev \
+  pkg-config \
   gcc \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This is the fix to (issue 850)[https://github.com/reworkd/AgentGPT/issues/850] which fails because it cannot find pkg-config on the docker image for platform.  It was a removed dependency in commit (30022a7).