### PR TITLE
912 banner badge glow in hero section

### DIFF
--- a/next/src/components/BannerBadge.tsx
+++ b/next/src/components/BannerBadge.tsx
@@ -1,4 +1,5 @@
-import { FaArrowRight } from "react-icons/fa";
+import React from "react";
+import { FaStar } from "react-icons/fa";
 import clsx from "clsx";
 
 type BannerBadgeProps = {
@@ -10,14 +11,15 @@ const BannerBadge = ({ children, onClick }: BannerBadgeProps) => {
   return (
     <div
       className={clsx(
-        "flex w-max cursor-pointer items-center gap-2 rounded-full border border-blue-300 bg-blue-500/40 px-3 py-1 text-xs text-blue-300",
-        "hover:border-blue-200 hover:bg-blue-500/60 hover:text-blue-200",
-        "transition-colors duration-300"
+        "relative flex w-max cursor-pointer items-center gap-1 rounded-full font-thin",
+        "border-2 border-purple-300/20 p-1 text-xs text-purple-300 transition-colors duration-300",
+        "before:absolute before:inset-0 before:animate-pulse before:bg-gradient-to-r before:from-purple-300/20 before:to-transparent"
       )}
       onClick={onClick}
     >
+      <FaStar className="ml-2 text-purple-300" />
       <span>{children}</span>
-      <FaArrowRight />
+      <div />
     </div>
   );
 };

--- a/next/src/components/BannerBadge.tsx
+++ b/next/src/components/BannerBadge.tsx
@@ -10,24 +10,27 @@ type BannerBadgeProps = {
 const BannerBadge = ({ children, onClick }: BannerBadgeProps) => {
   const badgeStyles = clsx(
     "relative flex w-max cursor-pointer items-center gap-1 rounded-full font-thin",
-    "border-2 border-purple-300/20 p-1 text-sm text-[#CC98FF] transition-colors duration-300",
-    "before:absolute before:inset-0 before:animate-pulse before:bg-gradient-to-r before:from-purple-300/20 before:to-transparent",
-    "before:content-' ' before:overflow-hidden before:rounded-full"
+    "border-2 border-purple-300/20 p-1 text-sm text-[#CC98FF]",
+    "animate-border-pulse"
   );
 
   return (
     <div className={badgeStyles} onClick={onClick}>
       <style>{`
-        @keyframes pulse-animation {
+        @keyframes border-pulse-animation {
           0% {
-            background-position: 0% 50%;
+            border-color: rgba(186, 166, 255, 0.2);
           }
           50% {
-            background-position: 100% 50%;
+            border-color: rgba(186, 166, 255, 0.4);
           }
           100% {
-            background-position: 0% 50%;
+            border-color: rgba(186, 166, 255, 0.2);
           }
+        }
+        
+        .animate-border-pulse {
+          animation: border-pulse-animation 2s infinite;
         }
       `}</style>
       <span>{children}</span>

--- a/next/src/components/BannerBadge.tsx
+++ b/next/src/components/BannerBadge.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FaArrowRight } from "react-icons/fa";
+import { IoSparkles } from "react-icons/io5";
 import clsx from "clsx";
 
 type BannerBadgeProps = {
@@ -9,32 +10,23 @@ type BannerBadgeProps = {
 
 const BannerBadge = ({ children, onClick }: BannerBadgeProps) => {
   const badgeStyles = clsx(
-    "relative flex w-max cursor-pointer items-center gap-1 rounded-full font-thin",
-    "border-2 border-purple-300/20 p-1 text-sm text-[#CC98FF]",
+    "group pr-2.5",
+    "relative flex w-max cursor-pointer items-center gap-1 rounded-full",
+    "border border-purple-300 pl-2 p-1 text-sm text-purple-300",
     "animate-border-pulse"
+  );
+
+  const arrowStyles = clsx(
+    "text-purple-300",
+    "transition-transform duration-300",
+    "transform-gpu group-hover:translate-x-1.5"
   );
 
   return (
     <div className={badgeStyles} onClick={onClick}>
-      <style>{`
-        @keyframes border-pulse-animation {
-          0% {
-            border-color: rgba(186, 166, 255, 0.2);
-          }
-          50% {
-            border-color: rgba(186, 166, 255, 0.4);
-          }
-          100% {
-            border-color: rgba(186, 166, 255, 0.2);
-          }
-        }
-        
-        .animate-border-pulse {
-          animation: border-pulse-animation 2s infinite;
-        }
-      `}</style>
+      <IoSparkles className="mx-1" />
       <span>{children}</span>
-      <FaArrowRight className="mx-1 text-[#CC98FF]" />
+      <FaArrowRight className={arrowStyles} />
     </div>
   );
 };

--- a/next/src/components/BannerBadge.tsx
+++ b/next/src/components/BannerBadge.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FaStar } from "react-icons/fa";
+import { FaArrowRight } from "react-icons/fa";
 import clsx from "clsx";
 
 type BannerBadgeProps = {
@@ -8,18 +8,30 @@ type BannerBadgeProps = {
 };
 
 const BannerBadge = ({ children, onClick }: BannerBadgeProps) => {
+  const badgeStyles = clsx(
+    "relative flex w-max cursor-pointer items-center gap-1 rounded-full font-thin",
+    "border-2 border-purple-300/20 p-1 text-sm text-[#CC98FF] transition-colors duration-300",
+    "before:absolute before:inset-0 before:animate-pulse before:bg-gradient-to-r before:from-purple-300/20 before:to-transparent",
+    "before:content-' ' before:overflow-hidden before:rounded-full"
+  );
+
   return (
-    <div
-      className={clsx(
-        "relative flex w-max cursor-pointer items-center gap-1 rounded-full font-thin",
-        "border-2 border-purple-300/20 p-1 text-xs text-purple-300 transition-colors duration-300",
-        "before:absolute before:inset-0 before:animate-pulse before:bg-gradient-to-r before:from-purple-300/20 before:to-transparent"
-      )}
-      onClick={onClick}
-    >
-      <FaStar className="ml-2 text-purple-300" />
+    <div className={badgeStyles} onClick={onClick}>
+      <style>{`
+        @keyframes pulse-animation {
+          0% {
+            background-position: 0% 50%;
+          }
+          50% {
+            background-position: 100% 50%;
+          }
+          100% {
+            background-position: 0% 50%;
+          }
+        }
+      `}</style>
       <span>{children}</span>
-      <div />
+      <FaArrowRight className="mx-1 text-[#CC98FF]" />
     </div>
   );
 };

--- a/next/src/styles/globals.css
+++ b/next/src/styles/globals.css
@@ -287,3 +287,19 @@ Not supports in Firefox and IE */
         opacity: 0;
     }
 }
+
+@keyframes border-pulse-animation {
+    0% {
+      border-color: rgba(216, 180, 254, 0.3);
+    }
+    50% {
+      border-color: rgba(216, 180, 254, 0.4);
+    }
+    100% {
+      border-color: rgba(216, 180, 254, 0.3);
+    }
+  }
+  
+  .animate-border-pulse {
+    animation: border-pulse-animation 2s infinite;
+  }


### PR DESCRIPTION
## About 

- Changed banner styling 
- Started on the pulsing 
- Unsure how to start the border glow train

## Notes

- For some reason react icons don't have the PiStarFourFill the star on Figma
- Pulsing isn't rounded and bleeds pixels making a square look 

**Before:**

<img width="352" alt="Screen Shot 2023-07-02 at 12 00 22 PM" src="https://github.com/reworkd/AgentGPT/assets/56135840/aff1a4a5-9f28-439d-89d3-f0101d56e8e9">

**After**

<img width="324" alt="Screen Shot 2023-07-02 at 12 23 07 PM" src="https://github.com/reworkd/AgentGPT/assets/56135840/88f735cd-7f98-4b39-ba9c-4a07370c7d12">

closes #912 