### PR TITLE
feat: Validate user API keys in CLI

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -19,6 +19,7 @@
         "inquirer": "^9.2.7",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
+        "node-fetch": "^3.3.1",
         "simple-git": "^3.19.0",
         "touch": "^3.1.0"
       },
@@ -148,6 +149,25 @@
         "@octokit/openapi-types": "^17.2.0"
       }
     },
+    "node_modules/@octokit/core/node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@octokit/endpoint": {
       "version": "6.0.12",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
@@ -224,6 +244,25 @@
       "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
       "dependencies": {
         "@octokit/openapi-types": "^17.2.0"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@octokit/openapi-types": {
@@ -316,6 +355,25 @@
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@octokit/rest": {
@@ -601,6 +659,14 @@
         "es5-ext": "~0.10.2"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -809,6 +875,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figlet": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.6.0.tgz",
@@ -833,6 +921,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -1071,23 +1170,39 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/nopt": {
@@ -1411,6 +1526,14 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -1575,6 +1698,14 @@
           "requires": {
             "@octokit/openapi-types": "^17.2.0"
           }
+        },
+        "node-fetch": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+          "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
         }
       }
     },
@@ -1642,6 +1773,14 @@
           "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
           "requires": {
             "@octokit/openapi-types": "^17.2.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+          "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         }
       }
@@ -1716,6 +1855,16 @@
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+          "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "@octokit/request-error": {
@@ -1922,6 +2071,11 @@
         "es5-ext": "~0.10.2"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2102,6 +2256,15 @@
         "tmp": "^0.0.33"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "figlet": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.6.0.tgz",
@@ -2114,6 +2277,14 @@
       "requires": {
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -2285,12 +2456,19 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
     "node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "requires": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "nopt": {
@@ -2528,6 +2706,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,6 +25,7 @@
     "inquirer": "^9.2.7",
     "lodash": "^4.17.21",
     "minimist": "^1.2.8",
+    "node-fetch": "^3.3.1",
     "simple-git": "^3.19.0",
     "touch": "^3.1.0"
   }

--- a/cli/src/helpers.js
+++ b/cli/src/helpers.js
@@ -20,9 +20,7 @@ export const printTitle = () => {
 
 // Function to check if entered api key is in the correct format or empty
 export const isValidKey = (apikey, pattern) => {
-  if (pattern.test(apikey) || apikey === "") {
-    return true;
-  } else {
-    return "\nInvalid api key. Please try again.";
-  }
+  return (apikey === "" || pattern.test(apikey))
 };
+
+export const validKeyErrorMessage = "\nInvalid api key. Please try again."

--- a/cli/src/helpers.js
+++ b/cli/src/helpers.js
@@ -18,8 +18,11 @@ export const printTitle = () => {
   );
 };
 
-// Function to check if entered api key is in the correct format
-export const isValidSkKey = (apikey) => {
-  const pattern = /^sk-[a-zA-Z0-9]{48}$/;
-  return pattern.test(apikey);
+// Function to check if entered api key is in the correct format or empty
+export const isValidKey = (apikey, pattern) => {
+  if (pattern.test(apikey) || apikey === "") {
+    return true;
+  } else {
+    return "\nInvalid api key. Please try again.";
+  }
 };

--- a/cli/src/questions/newEnvQuestions.js
+++ b/cli/src/questions/newEnvQuestions.js
@@ -1,4 +1,4 @@
-import { isValidKey } from "../helpers.js";
+import { isValidKey, validKeyErrorMessage } from "../helpers.js";
 import { RUN_OPTION_QUESTION } from "./sharedQuestions.js";
 
 export const newEnvQuestions = [
@@ -8,8 +8,22 @@ export const newEnvQuestions = [
     name: "OpenAIApiKey",
     message:
       "Enter your openai key (eg: sk...) or press enter to continue with no key:",
-    validate: (apikey) => {
-      return isValidKey(apikey, /^sk-[a-zA-Z0-9]{48}$/)
+    validate: async (apikey) => {
+      if(!isValidKey(apikey, /^sk-[a-zA-Z0-9]{48}$/)) {
+        return validKeyErrorMessage
+      }
+
+      const endpoint = "https://api.openai.com/v1/models"
+      const response = await fetch(endpoint, {
+        headers: {
+          "Authorization": `Bearer ${apikey}`,
+        },
+      });
+      if(!response.ok) {
+        return validKeyErrorMessage
+      }
+
+      return true
     },
   },
   {
@@ -17,8 +31,27 @@ export const newEnvQuestions = [
     name: "serpApiKey",
     message:
       "What is your SERP API key (https://serper.dev/)? Leave empty to disable web search.",
-    validate: (apikey) => {
-      return isValidKey(apikey, /^[a-zA-Z0-9]{40}$/)
+    validate: async (apikey) => {
+      if(!isValidKey(apikey, /^[a-zA-Z0-9]{40}$/)) {
+        return validKeyErrorMessage
+      }
+
+      const endpoint = "https://google.serper.dev/search"
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          "X-API-KEY": apikey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          "q": "apple inc"
+        }),
+      });
+      if(!response.ok) {
+        return validKeyErrorMessage
+      }
+
+      return true
     },
   },
   {
@@ -26,8 +59,22 @@ export const newEnvQuestions = [
     name: "replicateApiKey",
     message:
       "What is your Replicate API key (https://replicate.com/)? Leave empty to just use DALL-E for image generation.",
-    validate: (apikey) => {
-      return isValidKey(apikey, /^r8-[a-zA-Z0-9]{37}$/)
+    validate: async (apikey) => {
+      if(!isValidKey(apikey, /^r8_[a-zA-Z0-9]{37}$/)) {
+        return validKeyErrorMessage
+      }
+
+      const endpoint = "https://api.replicate.com/v1/models/replicate/hello-world"
+      const response = await fetch(endpoint, {
+        headers: {
+          "Authorization": `Token ${apikey}`,
+        },
+      });
+      if(!response.ok) {
+        return validKeyErrorMessage
+      }
+
+      return true
     },
   },
 ];

--- a/cli/src/questions/newEnvQuestions.js
+++ b/cli/src/questions/newEnvQuestions.js
@@ -1,80 +1,87 @@
 import { isValidKey, validKeyErrorMessage } from "../helpers.js";
 import { RUN_OPTION_QUESTION } from "./sharedQuestions.js";
+import fetch from "node-fetch";
 
 export const newEnvQuestions = [
-  RUN_OPTION_QUESTION,
-  {
-    type: "input",
-    name: "OpenAIApiKey",
-    message:
-      "Enter your openai key (eg: sk...) or press enter to continue with no key:",
-    validate: async (apikey) => {
-      if(!isValidKey(apikey, /^sk-[a-zA-Z0-9]{48}$/)) {
-        return validKeyErrorMessage
-      }
+    RUN_OPTION_QUESTION,
+    {
+        type: "input",
+        name: "OpenAIApiKey",
+        message:
+            "Enter your openai key (eg: sk...) or press enter to continue with no key:",
+        validate: async(apikey) => {
+            if(apikey === "") return true;
 
-      const endpoint = "https://api.openai.com/v1/models"
-      const response = await fetch(endpoint, {
-        headers: {
-          "Authorization": `Bearer ${apikey}`,
+            if(!isValidKey(apikey, /^sk-[a-zA-Z0-9]{48}$/)) {
+                return validKeyErrorMessage
+            }
+
+            const endpoint = "https://api.openai.com/v1/models"
+            const response = await fetch(endpoint, {
+                headers: {
+                    "Authorization": `Bearer ${apikey}`,
+                },
+            });
+            if(!response.ok) {
+                return validKeyErrorMessage
+            }
+
+            return true
         },
-      });
-      if(!response.ok) {
-        return validKeyErrorMessage
-      }
-
-      return true
     },
-  },
-  {
-    type: "input",
-    name: "serpApiKey",
-    message:
-      "What is your SERP API key (https://serper.dev/)? Leave empty to disable web search.",
-    validate: async (apikey) => {
-      if(!isValidKey(apikey, /^[a-zA-Z0-9]{40}$/)) {
-        return validKeyErrorMessage
-      }
+    {
+        type: "input",
+        name: "serpApiKey",
+        message:
+            "What is your SERP API key (https://serper.dev/)? Leave empty to disable web search.",
+        validate: async(apikey) => {
+            if(apikey === "") return true;
 
-      const endpoint = "https://google.serper.dev/search"
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          "X-API-KEY": apikey,
-          "Content-Type": "application/json",
+            if(!isValidKey(apikey, /^[a-zA-Z0-9]{40}$/)) {
+                return validKeyErrorMessage
+            }
+
+            const endpoint = "https://google.serper.dev/search"
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    "X-API-KEY": apikey,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    "q": "apple inc"
+                }),
+            });
+            if(!response.ok) {
+                return validKeyErrorMessage
+            }
+
+            return true
         },
-        body: JSON.stringify({
-          "q": "apple inc"
-        }),
-      });
-      if(!response.ok) {
-        return validKeyErrorMessage
-      }
-
-      return true
     },
-  },
-  {
-    type: "input",
-    name: "replicateApiKey",
-    message:
-      "What is your Replicate API key (https://replicate.com/)? Leave empty to just use DALL-E for image generation.",
-    validate: async (apikey) => {
-      if(!isValidKey(apikey, /^r8_[a-zA-Z0-9]{37}$/)) {
-        return validKeyErrorMessage
-      }
+    {
+        type: "input",
+        name: "replicateApiKey",
+        message:
+            "What is your Replicate API key (https://replicate.com/)? Leave empty to just use DALL-E for image generation.",
+        validate: async(apikey) => {
+            if(apikey === "") return true;
+            
+            if(!isValidKey(apikey, /^r8_[a-zA-Z0-9]{37}$/)) {
+                return validKeyErrorMessage
+            }
 
-      const endpoint = "https://api.replicate.com/v1/models/replicate/hello-world"
-      const response = await fetch(endpoint, {
-        headers: {
-          "Authorization": `Token ${apikey}`,
+            const endpoint = "https://api.replicate.com/v1/models/replicate/hello-world"
+            const response = await fetch(endpoint, {
+                headers: {
+                    "Authorization": `Token ${apikey}`,
+                },
+            });
+            if(!response.ok) {
+                return validKeyErrorMessage
+            }
+
+            return true
         },
-      });
-      if(!response.ok) {
-        return validKeyErrorMessage
-      }
-
-      return true
     },
-  },
 ];

--- a/cli/src/questions/newEnvQuestions.js
+++ b/cli/src/questions/newEnvQuestions.js
@@ -1,4 +1,4 @@
-import { isValidSkKey } from "../helpers.js";
+import { isValidKey } from "../helpers.js";
 import { RUN_OPTION_QUESTION } from "./sharedQuestions.js";
 
 export const newEnvQuestions = [
@@ -9,11 +9,7 @@ export const newEnvQuestions = [
     message:
       "Enter your openai key (eg: sk...) or press enter to continue with no key:",
     validate: (apikey) => {
-      if (isValidSkKey(apikey) || apikey === "") {
-        return true;
-      } else {
-        return "\nInvalid api key. Please try again.";
-      }
+      return isValidKey(apikey, /^sk-[a-zA-Z0-9]{48}$/)
     },
   },
   {
@@ -21,11 +17,17 @@ export const newEnvQuestions = [
     name: "serpApiKey",
     message:
       "What is your SERP API key (https://serper.dev/)? Leave empty to disable web search.",
+    validate: (apikey) => {
+      return isValidKey(apikey, /^[a-zA-Z0-9]{40}$/)
+    },
   },
   {
     type: "input",
     name: "replicateApiKey",
     message:
       "What is your Replicate API key (https://replicate.com/)? Leave empty to just use DALL-E for image generation.",
+    validate: (apikey) => {
+      return isValidKey(apikey, /^r8-[a-zA-Z0-9]{37}$/)
+    },
   },
 ];


### PR DESCRIPTION
This solution involves:
- [x]  Implement a key validation function within the setup.sh/newEnvQuestions.js.
- [x] Test the new function to ensure its effectiveness and reliability. (There is no testing tool setup in the `cli` folder, I did manual testing, should I set up one or does manual testing suffice for now?)
- [x] Update the setup documentation to inform users of this new feature. (Already mentioned in [Interactive Setup](https://docs.reworkd.ai/development/setup#interactive-setup))

Issue: #892