### PR TITLE
901: Reorder Tasks in Task Queue

### DIFF
--- a/next/src/components/TaskWindow.tsx
+++ b/next/src/components/TaskWindow.tsx
@@ -38,25 +38,35 @@ export const TaskWindow = ({ visibleOnMobile }: TaskWindowProps) => {
 
 
   
+  // For storing Index of the task which we want to drag
   const dragTaskIndex = React.useRef(null);
+  // When Task DragStarted
   const onDragStart = (e:React.DragEvent<HTMLDivElement>, i: number) => {
     dragTaskIndex.current = i;
+
+    // Making Task opacity zero in the task list. Using timeout because without it, it will make opacity 0 instantly and then the Task which is showing on cursor will also not visible
     setTimeout(() => {
       e.target.classList.add("opacity-0");
     }, 0);
   }
+  // When we drag the task upon another task
+  const onDragEnter = (i:number) => {
+    if (dragTaskIndex.current === null) return;
+    // Tasks Order will be updated only when the Task on which we are droping has `started` status 
+    if (tasks[i].status !== "started") return
+    const _items = [...tasks];
+    // removing the Task from array
+    const draggedItem = _items.splice(dragTaskIndex.current, 1)[0];
+    // inserting that element in new position where we want to drop
+    _items.splice(i, 0, draggedItem);
+    dragTaskIndex.current = i;
+    setTasks(_items)
+  }
+
+  // When we left the draging Task
   const onDragEnd = (e:React.DragEvent<HTMLDivElement>) => {
     dragTaskIndex.current = null;
     e.target.classList.remove("opacity-0");
-  }
-  const onDragEnter = (i:number) => {
-    if (dragTaskIndex.current === null) return;
-    if (tasks[i].status !== "started") return
-    const _items = [...tasks];
-    const draggedItem = _items.splice(dragTaskIndex.current, 1)[0];
-    _items.splice(i, 0, draggedItem)
-    dragTaskIndex.current = i;
-    setTasks(_items)
   }
 
   return (

--- a/next/src/stores/taskStore.ts
+++ b/next/src/stores/taskStore.ts
@@ -20,6 +20,7 @@ export interface TaskSlice {
   addTask: (newTask: Task) => void;
   updateTask: (updatedTask: Task) => void;
   deleteTask: (taskId: string) => void;
+  setTasks: (tasks: Task[]) => void;
 }
 
 export const createTaskSlice: StateCreator<TaskSlice, [], [], TaskSlice> = (set) => {
@@ -31,6 +32,12 @@ export const createTaskSlice: StateCreator<TaskSlice, [], [], TaskSlice> = (set)
       set((state) => ({
         ...state,
         tasks: [...state.tasks, { ...newTask }],
+      }));
+    },
+    setTasks: (tasks) => {
+      set((state) => ({
+        ...state,
+        tasks: [...tasks],
       }));
     },
     updateTask: (updatedTask) => {


### PR DESCRIPTION
Hello,

- Added Reorder Tasks using Drag and Drap
- Here I have implemented custom logic for updating the state because the default `Reorder` feature from framer-motion continuously updates the state when we drag and drop the element and this was hanging the website. (because we have to update the global state)
- So, I have implemented a function to update the global state only when we drag over another element.


https://github.com/reworkd/AgentGPT/assets/76877003/84da0a0b-bc10-43f3-b9e5-24e071543a26

e we have to update the global state)
- So, I have implemented a function to update the global state only when we drag over another element.

Thanks,
Abhishek