### PR TITLE
Fix/failed to read dockerfile/issue 984

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   weaviate:
     image: semitechnologies/weaviate:1.19.6
-    restart: on-failure:0
+    restart: on-failure:0 # this should be 'no' or at least have ':1'
     ports:
       - "8080:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,11 +68,6 @@ services:
     volumes:
       - weaviate:/var/lib/weaviate
 
-  docs:
-    build: ./docs
-    ports:
-      - "3001:3001"
-
 volumes:
   weaviate:
   db_data:


### PR DESCRIPTION
This is to fix [this issue](https://github.com/reworkd/AgentGPT/issues/984).
A `services` `docs` was added, but the `Dockerfile` is not present in the `docs` directory.