### PR TITLE
fix: apply anti-aliasing to text

### DIFF
--- a/next/src/styles/globals.css
+++ b/next/src/styles/globals.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
 body {
     background: black;
 }


### PR DESCRIPTION
Without anti-aliasing
![image](https://github.com/reworkd/AgentGPT/assets/22240630/8cbd213b-a279-4d69-b291-cba444908228)

WIth anti-aliasing
![image](https://github.com/reworkd/AgentGPT/assets/22240630/1016a614-4499-4703-88b6-82cbbcde89f3)


