### PR TITLE
🔧 Dynamic Consumer Groups

### DIFF
--- a/platform/pyproject.toml
+++ b/platform/pyproject.toml
@@ -89,9 +89,7 @@ filterwarnings = [
     "ignore::ImportWarning",
 ]
 env = [
-    "REWORKD_PLATFORM_ENVIRONMENT=pytest",
     "REWORKD_PLATFORM_DB_BASE=reworkd_platform_test",
-    "REWORKD_PLATFORM_SENTRY_DSN=",
 ]
 
 [build-system]

--- a/platform/reworkd_platform/services/kafka/consumers/base.py
+++ b/platform/reworkd_platform/services/kafka/consumers/base.py
@@ -25,12 +25,13 @@ class AsyncConsumer(ABC):
         self,
         *topics: Any,
         settings: Settings,
-        deserializer: Deserializer = JSONDeserializer()
+        deserializer: Deserializer = JSONDeserializer(),
     ):
+        self._group = settings.kafka_consumer_group
         self._consumer = settings.kafka_enabled and AIOKafkaConsumer(
             *topics,
             bootstrap_servers=settings.kafka_bootstrap_servers,
-            group_id="platform",
+            group_id=self._group,
             sasl_mechanism=settings.kafka_ssal_mechanism,
             security_protocol="SASL_SSL",
             sasl_plain_username=settings.kafka_username,
@@ -38,8 +39,10 @@ class AsyncConsumer(ABC):
             ssl_context=ssl.create_default_context(cafile=settings.db_ca_path),
             enable_auto_commit=True,
             auto_offset_reset="earliest",
-            value_deserializer=deserializer.deserialize
+            value_deserializer=deserializer.deserialize,
         )
+
+        self._dev_mode = settings.environment == "development"
 
     async def start(self) -> "AsyncConsumer":
         if not self._consumer:
@@ -50,11 +53,15 @@ class AsyncConsumer(ABC):
         await consumer.start()
 
         async def consumer_loop() -> None:
-            try:
-                async for msg in consumer:
+            async for msg in consumer:
+                if self.should_skip(msg):
+                    logger.info(f"Skipping message: {msg.headers}")
+                    continue
+
+                try:
                     await self.on_message(msg)
-            finally:
-                await self.stop()
+                except Exception as e:
+                    logger.exception(e)
 
         asyncio.get_event_loop().create_task(consumer_loop())
         return self
@@ -64,6 +71,12 @@ class AsyncConsumer(ABC):
             return
 
         await self._consumer.stop()
+
+    def should_skip(self, record: ConsumerRecord) -> bool:
+        return (
+            self._dev_mode
+            and ("host", self._group.encode("utf-8")) not in record.headers
+        )
 
     @abstractmethod
     async def on_message(self, record: ConsumerRecord) -> None:

--- a/platform/reworkd_platform/services/kafka/producers/base.py
+++ b/platform/reworkd_platform/services/kafka/producers/base.py
@@ -11,8 +11,6 @@ TOPICS = Literal["workflow_task"]
 
 
 class AsyncProducer:
-    _producer: AIOKafkaProducer
-
     def __init__(self, settings: Settings):
         self._producer = settings.kafka_enabled and AIOKafkaProducer(
             bootstrap_servers=settings.kafka_bootstrap_servers,
@@ -21,6 +19,12 @@ class AsyncProducer:
             sasl_plain_username=settings.kafka_username,
             sasl_plain_password=settings.kafka_password,
             ssl_context=create_default_context(cafile=settings.db_ca_path),
+        )
+
+        self._headers = (
+            [("host", settings.kafka_consumer_group.encode("utf-8"))]
+            if settings.environment == "development"
+            else None
         )
 
     @classmethod
@@ -39,4 +43,8 @@ class AsyncProducer:
             logger.warning("Kafka producer is not enabled")
             return
 
-        await self._producer.send(topic=topic, value=data.json().encode("utf-8"))
+        await self._producer.send(
+            topic=topic,
+            value=data.json().encode("utf-8"),
+            headers=self._headers,
+        )

--- a/platform/reworkd_platform/settings.py
+++ b/platform/reworkd_platform/settings.py
@@ -1,4 +1,5 @@
 import enum
+import platform
 from pathlib import Path
 from tempfile import gettempdir
 from typing import List, Optional, Literal, Union
@@ -27,6 +28,11 @@ SASL_MECHANISM = Literal[
     "SCRAM-SHA-256",
 ]
 
+ENVIRONMENT = Literal[
+    "development",
+    "production",
+]
+
 
 class Settings(BaseSettings):
     """
@@ -46,7 +52,7 @@ class Settings(BaseSettings):
     reload: bool = True
 
     # Current environment
-    environment: str = "development"
+    environment: ENVIRONMENT = "development"
 
     log_level: LogLevel = LogLevel.INFO
 
@@ -101,6 +107,13 @@ class Settings(BaseSettings):
     # Application Settings
     ff_mock_mode_enabled: bool = False  # Controls whether calls are mocked
     max_loops: int = 25  # Maximum number of loops to run
+
+    @property
+    def kafka_consumer_group(self) -> str:
+        if self.environment == "development":
+            return platform.node()
+
+        return "platform"
 
     @property
     def db_url(self) -> URL:

--- a/platform/reworkd_platform/settings.py
+++ b/platform/reworkd_platform/settings.py
@@ -110,6 +110,11 @@ class Settings(BaseSettings):
 
     @property
     def kafka_consumer_group(self) -> str:
+        """
+        Kafka consumer group will be the name of the host in development
+        mode, making it easier to share a dev cluster.
+        """
+
         if self.environment == "development":
             return platform.node()
 
@@ -117,11 +122,6 @@ class Settings(BaseSettings):
 
     @property
     def db_url(self) -> URL:
-        """
-        Assemble database URL from settings.
-
-        :return: database URL.
-        """
         return URL.build(
             scheme="mysql+aiomysql",
             host=self.db_host,


### PR DESCRIPTION
- Allows devs to share a single kafka cluster
- In dev mode, you will only consume message you produce
- Each person on the cluster will be assinged thier own consumer group
- Messages will be skipped if it is not produced by your maching
- Each consumer group keeps track of its own oftset