### PR TITLE
Adding tenacity retries + timeouts to Claude and adding model abstraction class

### DIFF
--- a/platform/pyproject.toml
+++ b/platform/pyproject.toml
@@ -51,7 +51,7 @@ slack-sdk = "^3.21.3"
 python-docx = "^0.8.11"
 scrapingbee = "^1.2.0"
 anthropic = "^0.3.6"
-
+litellm = "^0.1.226"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^2.0.2"


### PR DESCRIPTION
Hi, 

responding to this comment on the claude PR - https://github.com/reworkd/AgentGPT/pull/1146/files/ff3d52d4a7abd848b6691af75e115f477db3d4f9

I replaced calling the raw Claude endpoint, with `litellm` - this introduces retries and timeouts to claude. 

Since it's a model abstraction class - it also lets you use the same call + params to switch between PaLM, Llama2 (replicate), Cohere, Azure, OpenAI

Let me know if this helps! 