### PR TITLE
✏️ Content agent bullet output

### DIFF
--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 import requests
 from bs4 import BeautifulSoup
@@ -14,7 +14,7 @@ from reworkd_platform.settings import settings
 
 class ContentRefresherInput(BlockIOBase):
     url: str
-    competitors: str
+    competitors: Optional[str] = None
 
 
 class ContentRefresherOutput(ContentRefresherInput):
@@ -76,6 +76,14 @@ class ContentRefresherAgent(Block):
         updated_target_content = await add_info(target_content, new_infos)
         # logger.info(updated_target_content)
         log("Content refresh concluded")
+        
+        logger.info("Content refresh complete")
+        logger.info("Content refresh complete")
+        logger.info("Content refresh complete")
+        logger.info("Content refresh complete")
+        logger.info("Content refresh complete")
+        logger.info(updated_target_content)
+        logger.info(new_infos)
 
         return ContentRefresherOutput(
             **self.input.dict(),
@@ -187,7 +195,7 @@ def remove_competitors(
         if competitor_pattern.search(
             source["url"].replace(" ", "").lower()
         ) or competitor_pattern.search(source["title"].replace(" ", "").lower()):
-            log(f"Removing source due to competitor match:, '{source['title']}'")
+            log(f"Removing source due to competitor match: '{source['title']}'")
         else:
             filtered_sources.append(source)
 

--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -18,7 +18,7 @@ class ContentRefresherInput(BlockIOBase):
 
 
 class ContentRefresherOutput(ContentRefresherInput):
-    original_content: str
+    original_report: str
     refreshed_report: str
     refreshed_bullet_points: str
 
@@ -80,7 +80,7 @@ class ContentRefresherAgent(Block):
 
         return ContentRefresherOutput(
             **self.input.dict(),
-            original_content=target_content,
+            original_report=target_content,
             refreshed_report=updated_target_content,
             refreshed_bullet_points=new_infos,
         )

--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -188,7 +188,7 @@ def remove_competitors(
         if competitor_pattern.search(
             source["url"].replace(" ", "").lower()
         ) or competitor_pattern.search(source["title"].replace(" ", "").lower()):
-            log(f"Removing source due to competitor match: '{source['title']}'")
+            log(f"Removing competitive source: '{source['title']}'")
         else:
             filtered_sources.append(source)
 

--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -216,7 +216,7 @@ async def find_new_info(
     )
 
     new_info = "\n".join(response.split("\n\n"))
-    new_info += "\n\nsource: " + source_metadata
+    new_info += "\n\nSource: " + source_metadata
     return new_info
 
 

--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -77,20 +77,12 @@ class ContentRefresherAgent(Block):
         updated_target_content = await add_info(target_content, new_infos)
         # logger.info(updated_target_content)
         log("Content refresh concluded")
-        
-        logger.info("Content refresh complete")
-        logger.info("Content refresh complete")
-        logger.info("Content refresh complete")
-        logger.info("Content refresh complete")
-        logger.info("Content refresh complete")
-        logger.info(updated_target_content)
-        logger.info(new_infos)
 
         return ContentRefresherOutput(
             **self.input.dict(),
             original_content=target_content,
             refreshed_report=updated_target_content,
-            refreshed_bullet_points=new_infos
+            refreshed_bullet_points=new_infos,
         )
 
 

--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -19,7 +19,8 @@ class ContentRefresherInput(BlockIOBase):
 
 class ContentRefresherOutput(ContentRefresherInput):
     original_content: str
-    refreshed_content: str
+    refreshed_report: str
+    refreshed_bullet_points: str
 
 
 class ContentRefresherAgent(Block):
@@ -78,7 +79,8 @@ class ContentRefresherAgent(Block):
         return ContentRefresherOutput(
             **self.input.dict(),
             original_content=target_content,
-            refreshed_content=updated_target_content,
+            refreshed_report=updated_target_content,
+            refreshed_bullet_points=new_infos
         )
 
 

--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -70,7 +70,8 @@ class ContentRefresherAgent(Block):
 
         new_infos = "\n\n".join(new_info)
         log("Extracting new, relevant information not present in your content")
-        log(new_infos)
+        for info in new_info:
+            log(info)
 
         log("Updating provided content with new information")
         updated_target_content = await add_info(target_content, new_infos)

--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -41,7 +41,7 @@ class ContentRefresherAgent(Block):
 
         keywords = await find_content_kws(target_content)
         log("Finding keywords from source content")
-        log("\n".join([f"- {keyword}" for keyword in keywords.split(" ")]))
+        log("Keywords:\n" + "\n".join([f"- {keyword}" for keyword in keywords.split(" ")]))
 
         sources = search_results(keywords)
         sources = [
@@ -216,7 +216,7 @@ async def find_new_info(
     )
 
     new_info = "\n".join(response.split("\n\n"))
-    new_info += "\n" + source_metadata
+    new_info += "\n\nsource: " + source_metadata
     return new_info
 
 

--- a/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
+++ b/platform/reworkd_platform/schemas/workflow/blocks/agents/content_refresher_agent.py
@@ -41,7 +41,10 @@ class ContentRefresherAgent(Block):
 
         keywords = await find_content_kws(target_content)
         log("Finding keywords from source content")
-        log("Keywords:\n" + "\n".join([f"- {keyword}" for keyword in keywords.split(" ")]))
+        log(
+            "Keywords:\n"
+            + "\n".join([f"- {keyword}" for keyword in keywords.split(" ")])
+        )
 
         sources = search_results(keywords)
         sources = [


### PR DESCRIPTION
- additional output on content refresher agent (bullet points of infos from each source)
- fix 'workflow failed: too much data' error (iterate and log new_infos rather than one-liner)
- make `competitors` input optional