### PR TITLE
😈 Bug squash

### DIFF
--- a/next/src/components/workflow/Flowchart.tsx
+++ b/next/src/components/workflow/Flowchart.tsx
@@ -134,15 +134,18 @@ const FlowChart = forwardRef<FlowChartHandles, FlowChartProps>(
         const currentEdges = edgesModel.get();
         const updatedEdges = addEdge({ ...connection, animated: true }, currentEdges ?? []);
         setEdges(updatedEdges);
+
+        connectionDragging.current = false;
       },
       [setEdges, edgesModel]
     );
 
     const onConnectEnd = useCallback(
       (event: MouseEvent | TouchEvent) => {
-        if (!connectionDragging.current) return;
-        connectionDragging.current = false;
-        onPaneDoubleClick(getExactPosition(event));
+        if (connectionDragging.current) {
+          connectionDragging.current = false;
+          onPaneDoubleClick(getExactPosition(event));
+        }
       },
       [getExactPosition, onPaneDoubleClick, connectionDragging]
     );

--- a/next/src/components/workflow/Flowchart.tsx
+++ b/next/src/components/workflow/Flowchart.tsx
@@ -129,6 +129,8 @@ const FlowChart = forwardRef<FlowChartHandles, FlowChartProps>(
 
     const onConnect = useCallback(
       (connection: Connection) => {
+        if (connection.source === connection.target) return;
+
         const currentEdges = edgesModel.get();
         const updatedEdges = addEdge({ ...connection, animated: true }, currentEdges ?? []);
         setEdges(updatedEdges);

--- a/next/src/components/workflow/Flowchart.tsx
+++ b/next/src/components/workflow/Flowchart.tsx
@@ -142,10 +142,9 @@ const FlowChart = forwardRef<FlowChartHandles, FlowChartProps>(
 
     const onConnectEnd = useCallback(
       (event: MouseEvent | TouchEvent) => {
-        if (connectionDragging.current) {
-          connectionDragging.current = false;
-          onPaneDoubleClick(getExactPosition(event));
-        }
+        if (!connectionDragging.current) return;
+        connectionDragging.current = false;
+        onPaneDoubleClick(getExactPosition(event));
       },
       [getExactPosition, onPaneDoubleClick, connectionDragging]
     );


### PR DESCRIPTION
- fixed 'node self-connection' bug
- if connect to block, don't open blockDialog