### PR TITLE
Generate personalized agent goals for personal data interaction

### DIFF
--- a/next/src/components/console/ExampleAgents.tsx
+++ b/next/src/components/console/ExampleAgents.tsx
@@ -8,6 +8,8 @@ import { useSID } from "../../hooks/useSID";
 import { MESSAGE_TYPE_SYSTEM } from "../../types/message";
 import Button from "../Button";
 import FadeIn from "../motions/FadeIn";
+import Loader from "../loader";
+import { useTools } from "../../hooks/useTools";
 import { env } from "../../env/client.mjs";
 
 type ExampleAgentsProps = {
@@ -18,6 +20,9 @@ type ExampleAgentsProps = {
 const ExampleAgents = ({ setAgentRun, setShowSignIn }: ExampleAgentsProps) => {
   const { data: session } = useSession();
   const sid = useSID(session);
+  const tools = useTools();
+
+  let [sidLoading, setSidLoading] = React.useState(false);
 
   return (
     <>
@@ -36,41 +41,54 @@ const ExampleAgents = ({ setAgentRun, setShowSignIn }: ExampleAgentsProps) => {
             Plan a detailed trip to Hawaii.
           </ExampleAgentButton>
 
-          {env.NEXT_PUBLIC_FF_SID_ENABLED && (
-            <div
+          {env.NEXT_PUBLIC_FF_SID_ENABLED && (<div
+            className={clsx(
+              `w-full p-2`,
+              `cursor-pointer rounded-lg font-mono text-sm sm:text-base`,
+              `border border-white/20 bg-gradient-to-t from-sky-500 to-sky-600 transition-all hover:bg-gradient-to-t hover:from-sky-400 hover:to-sky-600`
+            )}
+            onClick={async () => {
+              if (!session?.user) setShowSignIn(true);
+              else if (!sid?.connected) sid.install().catch(console.error);
+              else {
+                setSidLoading(true);
+                try {
+                  const res = await sid.getPrompt();
+                  const prompt = res?.prompt ?? "Based on my personal data, evaluate my personal goals and give me advice.";
+                  tools.deactivateAll();
+                  tools.setToolActive("sid", true);
+                  setAgentRun?.("AssistantGPT", prompt);
+                } catch (e) {
+                  console.error(e);
+                } finally {
+                  setSidLoading(false);
+                }
+              }
+            }}
+          >
+            <p className="text-lg font-black">AssistantGPT 🛟</p>
+            <p className="mt-2 text-sm">Allow the agent to interact with your data</p>
+            {sidLoading && (
+              <div className="flex justify-center items-center flex-row">
+                <Loader className="" />
+              </div>
+            )}
+            <Button
+              ping={!sid?.connected}
               className={clsx(
-                `w-full p-2`,
-                `cursor-pointer rounded-lg font-mono text-sm sm:text-base`,
-                `border border-white/20 bg-gradient-to-t from-sky-500 to-sky-600 transition-all hover:bg-gradient-to-t hover:from-sky-400 hover:to-sky-600`
+                "w-full border-white/20 bg-gradient-to-t from-amber-500 to-amber-600 transition-all hover:bg-gradient-to-t hover:from-amber-400 hover:to-amber-600 sm:mt-4",
+                sid.connected && "hidden"
               )}
-              onClick={() => {
+              onClick={async () => {
                 if (!session?.user) setShowSignIn(true);
-                else if (!sid?.connected) sid.install().catch(console.error);
-                else
-                  setAgentRun?.(
-                    "AssistantGPT 🛟",
-                    "Search my google drive, dropbox, and notion, and talk to me about my personal data."
-                  );
+                else await sid.install();
               }}
+              loader
             >
-              <p className="text-lg font-black">AssistantGPT 🛟</p>
-              <p className="mt-2 text-sm">Get tailored advice based on your own data</p>
-              <Button
-                ping={!sid?.connected}
-                className={clsx(
-                  "w-full border-white/20 bg-gradient-to-t from-amber-500 to-amber-600 transition-all hover:bg-gradient-to-t hover:from-amber-400 hover:to-amber-600 sm:mt-4",
-                  sid.connected && "hidden"
-                )}
-                onClick={async () => {
-                  if (!session?.user) setShowSignIn(true);
-                  else await sid.install();
-                }}
-                loader
-              >
-                Connect your Data
-              </Button>
-            </div>
-          )}
+              Connect your Data
+            </Button>
+          </div>)}
+
 
           {env.NEXT_PUBLIC_FF_SID_ENABLED || (
             <ExampleAgentButton name="StudyGPT 📚" setAgentRun={setAgentRun}>

--- a/next/src/hooks/useSID.ts
+++ b/next/src/hooks/useSID.ts
@@ -27,11 +27,22 @@ export function useSID(session: Session | null) {
     queryClient.setQueriesData(QUERY_KEY, { connected: false });
   });
 
+  const getPrompt = async () => {
+    if (!session) return;
+
+    try {
+      return await api.get_prompt_sid();
+    } catch {
+      return undefined;
+    }
+  };
+
   return {
     connected: data?.connected ?? false,
     refetch,
     install: async () => install(),
     uninstall: async () => uninstall(),
+    getPrompt,
     manage: () => void window.open("https://me.sid.ai/", "_blank"),
   };
 }

--- a/next/src/hooks/useTools.ts
+++ b/next/src/hooks/useTools.ts
@@ -70,9 +70,19 @@ export function useTools() {
     });
   };
 
+  const deactivateAll = () => {
+    queryClient.setQueriesData(["tools"], (old) => {
+      const data = (old as ActiveTool[]).map((tool) => ({ ...tool, active: false }));
+
+      updateActiveTools(data);
+      return data;
+    });
+  }
+
   return {
     activeTools: query.data ?? [],
     setToolActive,
     isSuccess: query.isSuccess,
+    deactivateAll,
   };
 }

--- a/next/src/services/workflow/oauthApi.ts
+++ b/next/src/services/workflow/oauthApi.ts
@@ -63,4 +63,15 @@ export default class OauthApi {
       this.organizationId
     );
   }
+
+  async get_prompt_sid() {
+    return await get(
+      `/api/auth/sid/prompt`,
+      z.object({
+        prompt: z.string(),
+      }),
+      this.accessToken,
+      this.organizationId
+    );
+  }
 }

--- a/platform/reworkd_platform/web/api/agent/prompts.py
+++ b/platform/reworkd_platform/web/api/agent/prompts.py
@@ -157,7 +157,9 @@ summarize_sid_prompt = PromptTemplate(
     Write using clear markdown formatting in a style expected of the goal "{goal}".
     Be as clear, informative, and descriptive as necessary and attempt to
     answer the query: "{query}" as best as possible.
-    If any of the snippets are not relevant to the query, ignore them, and do not include them in the summary.
+    If any of the snippets are not relevant to the query, 
+    ignore them, and do not include them in the summary.
+    Do not mention that you are ignoring them.
 
     If there is no information provided, say "There is nothing to summarize".
     """,

--- a/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
+++ b/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
@@ -1,11 +1,12 @@
 import json
 from datetime import datetime, timedelta
-from typing import Any, List
+from typing import Any, List, Optional
 
 import aiohttp
 from fastapi.responses import StreamingResponse as FastAPIStreamingResponse
 from loguru import logger
 
+from reworkd_platform.db.models.auth import OauthCredentials
 from reworkd_platform.db.crud.oauth import OAuthCrud
 from reworkd_platform.schemas.user import UserBase
 from reworkd_platform.services.security import encryption_service
@@ -35,7 +36,7 @@ async def _sid_search_results(
             return search_results
 
 
-async def get_new_token(refresh_token: str) -> tuple[str, datetime]:
+async def token_exchange(refresh_token: str) -> tuple[str, datetime]:
     data = {
         "grant_type": "refresh_token",
         "client_id": settings.sid_client_id,
@@ -52,6 +53,18 @@ async def get_new_token(refresh_token: str) -> tuple[str, datetime]:
             access_token = response_data["access_token"]
             expires_in = response_data["expires_in"]
     return access_token, datetime.now() + timedelta(seconds=expires_in)
+
+async def get_access_token(oauth_crud: OAuthCrud, installation: OauthCredentials) -> Optional[str]:
+    if not installation.refresh_token_enc:
+        return None
+    if installation.access_token_expiration > datetime.now() - timedelta(minutes=5):
+        refresh_token = encryption_service.decrypt(installation.refresh_token_enc)
+        access_token, expiration = await token_exchange(refresh_token)
+        installation.access_token_enc = encryption_service.encrypt(access_token)
+        installation.access_token_expiration = expiration
+        await installation.save(oauth_crud.session)
+
+    return encryption_service.decrypt(installation.access_token_enc)
 
 
 class SID(Tool):
@@ -90,21 +103,14 @@ class SID(Tool):
         installation = await oauth_crud.get_installation_by_user_id(
             user_id=user.id, provider="sid"
         )
-
         # if the tool is called, the installation should be available. However, it is possible that it is
         # disconnected in the meantime. In that case, we pretend as if no information is found.
-        if not installation or not installation.access_token_enc:
+        if not installation:
             return stream_string("Unable to fetch SID results", True)
 
-        # update token if close to expiration
-        if installation.access_token_expiration > datetime.now() - timedelta(minutes=5):
-            refresh_token = encryption_service.decrypt(installation.refresh_token_enc)
-            access_token, expiration = await get_new_token(refresh_token)
-            installation.access_token_enc = encryption_service.encrypt(access_token)
-            installation.access_token_expiration = expiration
-            await installation.save(oauth_crud.session)
-
-        token = encryption_service.decrypt(installation.access_token_enc)
+        token = await get_access_token(oauth_crud, installation)
+        if not token:
+            return stream_string("Unable to fetch SID results", True)
 
         res = await _sid_search_results(input_str, limit=10, token=token)
         try:

--- a/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
+++ b/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
@@ -57,7 +57,7 @@ async def token_exchange(refresh_token: str) -> tuple[str, datetime]:
 async def get_access_token(oauth_crud: OAuthCrud, installation: OauthCredentials) -> Optional[str]:
     if not installation.refresh_token_enc:
         return None
-    if installation.access_token_expiration > datetime.now() - timedelta(minutes=5):
+    if datetime.now() + timedelta(minutes=5) > installation.access_token_expiration:
         refresh_token = encryption_service.decrypt(installation.refresh_token_enc)
         access_token, expiration = await token_exchange(refresh_token)
         installation.access_token_enc = encryption_service.encrypt(access_token)
@@ -112,8 +112,8 @@ class SID(Tool):
         if not token:
             return stream_string("Unable to fetch SID results", True)
 
-        res = await _sid_search_results(input_str, limit=10, token=token)
         try:
+            res = await _sid_search_results(input_str, limit=10, token=token)
             snippets: List[Snippet] = [
                 Snippet(text=result["text"]) for result in (res.get("results", []))
             ]


### PR DESCRIPTION
This PR introduces functionality to generate a custom agent goal when the user interacts with AssistantGPT. This goal is generated using the SID "example" endpoint, which generates prompts that could be answered with the user's connected data sources. The goal of this is to better show users the possible uses of a personal data agent, and to allow them to get a better out of the box experience.

Furthermore, the active tools used by the AssistantGPT example agent are modified to only include SID, allowing it to better stay on track and use the SID tool. I'm not too sure about this change: It definitely improves the agent's performance when dealing with personal data and the SID tool, but it may be confusing to the user.