### PR TITLE
fix: update twitter logo to X

### DIFF
--- a/next/src/components/dialog/HelpDialog.tsx
+++ b/next/src/components/dialog/HelpDialog.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "next-i18next";
 import React, { useEffect, useState } from "react";
-import { FaDiscord, FaGithub, FaTwitter } from "react-icons/fa";
+import { FaDiscord, FaGithub } from "react-icons/fa";
+import {FaXTwitter} from 'react-icons/fa6';
 
 import Dialog from "../../ui/dialog";
 
@@ -65,7 +66,7 @@ export default function HelpDialog() {
               )
             }
           >
-            <FaTwitter size={30} />
+            <FaXTwitter size={30} />
           </div>
           <div
             className="cursor-pointer rounded-full bg-slate-6 p-3 hover:bg-slate-8"

--- a/next/src/components/sidebar/links.tsx
+++ b/next/src/components/sidebar/links.tsx
@@ -9,9 +9,9 @@ import {
   FaHome,
   FaLinkedin,
   FaQuestion,
-  FaTwitter,
   FaWater,
 } from "react-icons/fa";
+import {FaXTwitter} from 'react-icons/fa6';
 
 type LinkMetadata = {
   name: string;
@@ -85,7 +85,7 @@ export const SOCIAL_LINKS: LinkMetadata[] = [
   {
     name: "Twitter",
     href: "https://twitter.com/ReworkdAI",
-    icon: FaTwitter,
+    icon: FaXTwitter,
     enabled: true,
   },
   {


### PR DESCRIPTION
fixes #1330 
Currently twitter icon was using `react-icons/fa` (fonts awesome 5)
Newer version is `react-icons/fa6` (fonts awesome 6)

New Preview - 
![image](https://github.com/reworkd/AgentGPT/assets/82658685/38093aaf-55cf-470f-8abb-b14afe4de76f)
