### PR TITLE
fix: update db container name instances in env

### DIFF
--- a/cli/src/envGenerator.js
+++ b/cli/src/envGenerator.js
@@ -57,7 +57,7 @@ const getEnvDefinition = (envValues, isDockerCompose, dbPort, platformUrl) => {
     "Database (Backend)": {
       REWORKD_PLATFORM_DATABASE_USER: "reworkd_platform",
       REWORKD_PLATFORM_DATABASE_PASSWORD: "reworkd_platform",
-      REWORKD_PLATFORM_DATABASE_HOST: "db",
+      REWORKD_PLATFORM_DATABASE_HOST: "agentgpt_db",
       REWORKD_PLATFORM_DATABASE_PORT: dbPort,
       REWORKD_PLATFORM_DATABASE_NAME: "reworkd_platform",
       REWORKD_PLATFORM_DATABASE_URL:
@@ -66,7 +66,7 @@ const getEnvDefinition = (envValues, isDockerCompose, dbPort, platformUrl) => {
     "Database (Frontend)": {
       DATABASE_USER: "reworkd_platform",
       DATABASE_PASSWORD: "reworkd_platform",
-      DATABASE_HOST: "db",
+      DATABASE_HOST: "agentgpt_db",
       DATABASE_PORT: dbPort,
       DATABASE_NAME: "reworkd_platform",
       DATABASE_URL:

--- a/platform/entrypoint.sh
+++ b/platform/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-host=db
+host=agentgpt_db
 port=3306
 
 until echo "SELECT 1;" | nc "$host" "$port" > /dev/null 2>&1; do


### PR DESCRIPTION
Fixes #1332 

Context:
The mysql container was renamed in a big PR (#1327) and the env files were left out thus new setups fail