### PR TITLE
In SID tool, fall back to normal search if no results are available

### DIFF
--- a/next/src/components/dialog/ToolsDialog.tsx
+++ b/next/src/components/dialog/ToolsDialog.tsx
@@ -88,7 +88,6 @@ const SidTool = ({ tool, onChange }: ToolProps) => {
       <div className="flex flex-grow flex-col gap-1">
         <p className="font-bold capitalize">{tool.name}</p>
         <p className="text-xs sm:text-sm">{tool.description}</p>
-      </div>
       {sid.connected && (
         <>
           <Button onClick={sid.manage}>Manage</Button>
@@ -98,8 +97,9 @@ const SidTool = ({ tool, onChange }: ToolProps) => {
           >
             Disconnect
           </Button>
-        </>
+         </>
       )}
+      </div>
       <Switch
         value={!sid?.connected ?? false ? false : tool.active}
         onChange={() => onChange(tool.name, !tool.active)}

--- a/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
+++ b/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
@@ -137,13 +137,7 @@ class SID(Tool):
         *args: Any,
         **kwargs: Any,
     ) -> FastAPIStreamingResponse:
-        res = await self._run_sid(
-            goal, task, input_str, user, oauth_crud
-        )
-        if res is None:
-            # fall back to search if no results are found
-            return await Search(self.model, self.language).call(
-                goal, task, input_str, user, oauth_crud
-            )
-        else:
-            return res
+         # fall back to search if no results are found
+        return await self._run_sid(goal, task, input_str, user, oauth_crud) or await Search(self.model, self.language).call(
+        goal, task, input_str, user, oauth_crud
+    )

--- a/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
+++ b/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
@@ -15,6 +15,8 @@ from reworkd_platform.web.api.agent.stream_mock import stream_string
 from reworkd_platform.web.api.agent.tools.tool import Tool
 from reworkd_platform.web.api.agent.tools.utils import Snippet, summarize_sid
 
+from reworkd_platform.web.api.agent.tools.search import Search
+
 
 async def _sid_search_results(
     search_term: str, limit: int, token: str
@@ -90,6 +92,41 @@ class SID(Tool):
 
         return bool(installation and installation.access_token_enc)
 
+    async def _run_sid(
+        self,
+        goal: str,
+        task: str,
+        input_str: str,
+        user: UserBase,
+        oauth_crud: OAuthCrud,
+    ) -> Optional[FastAPIStreamingResponse]:
+        installation = await oauth_crud.get_installation_by_user_id(
+            user_id=user.id, provider="sid"
+        )
+        if not installation:
+            logger.warning("No sid installation found for user {user.id}")
+            return None
+
+        token = await get_access_token(oauth_crud, installation)
+        if not token:
+            logger.warning("Unable to fetch sid access token for {user.id}")
+            return None
+
+        try:
+            res = await _sid_search_results(input_str, limit=10, token=token)
+            snippets: List[Snippet] = [
+                Snippet(text=result["text"]) for result in (res.get("results", []))
+            ]
+        except Exception as e:
+            logger.exception(e)
+            return None
+
+        if not snippets:
+            return None
+
+        return summarize_sid(self.model, self.language, goal, task, snippets)
+
+
     async def call(
         self,
         goal: str,
@@ -100,28 +137,13 @@ class SID(Tool):
         *args: Any,
         **kwargs: Any,
     ) -> FastAPIStreamingResponse:
-        installation = await oauth_crud.get_installation_by_user_id(
-            user_id=user.id, provider="sid"
+        res = await self._run_sid(
+            goal, task, input_str, user, oauth_crud
         )
-        # if the tool is called, the installation should be available. However, it is possible that it is
-        # disconnected in the meantime. In that case, we pretend as if no information is found.
-        if not installation:
-            return stream_string("Unable to fetch SID results", True)
-
-        token = await get_access_token(oauth_crud, installation)
-        if not token:
-            return stream_string("Unable to fetch SID results", True)
-
-        try:
-            res = await _sid_search_results(input_str, limit=10, token=token)
-            snippets: List[Snippet] = [
-                Snippet(text=result["text"]) for result in (res.get("results", []))
-            ]
-        except Exception as e:
-            logger.exception(e)
-            return stream_string("Unable to fetch SID results", True)
-
-        if not snippets:
-            return stream_string("No good results found by SID", True)
-
-        return summarize_sid(self.model, self.language, goal, task, snippets)
+        if res is None:
+            # fall back to search if no results are found
+            return Search(self.model, self.language).call(
+                goal, task, input_str, user, oauth_crud
+            )
+        else:
+            return res

--- a/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
+++ b/platform/reworkd_platform/web/api/agent/tools/sidsearch.py
@@ -142,7 +142,7 @@ class SID(Tool):
         )
         if res is None:
             # fall back to search if no results are found
-            return Search(self.model, self.language).call(
+            return await Search(self.model, self.language).call(
                 goal, task, input_str, user, oauth_crud
             )
         else:


### PR DESCRIPTION
These changes make it so that, if the SID tool cannot find any relevant information, or if the tool experiences some other issue (e.g. expired token, network issues, etc.), the agent automatically falls back to a standard google search.

Also, alignment of buttons in the tool menu is fixed for the SID tool.