### PR TITLE
feat[i18n]: add ide extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "inlang.vs-code-extension"
+  ]
+}

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://inlang.com/schema/project-settings",
+    "sourceLanguageTag": "en",
+    "languageTags": [
+      "en", "de", "es", "fr", "hr", "hu", "it", "ja", "ko", "lt", "nl", "pl", "pt", "ro", "ru", "sk", "tr", "uk", "zh"
+    ],
+    "modules": [
+      "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@4/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-empty-pattern@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js"
+    ],
+    "plugin.inlang.i18next": {
+      "pathPattern": {
+        "chat": "./next/public/locales/{languageTag}/chat.json",
+        "common": "./next/public/locales/{languageTag}/common.json",
+        "drawer": "./next/public/locales/{languageTag}/drawer.json",
+        "error": "./next/public/locales/{languageTag}/error.json",
+        "help": "./next/public/locales/{languageTag}/help.json",
+        "indexPage": "./next/public/locales/{languageTag}/indexPage.json",
+        "languages": "./next/public/locales/{languageTag}/languages.json",
+        "settings": "./next/public/locales/{languageTag}/settings.json"
+      }
+    }
+}
+


### PR DESCRIPTION
> let me know what needs to be changed in order to merge this

# Description: DX upgrade with little i18n tool.
- I added an [ide-extension](https://inlang.com/m/r7kp499g/app-inlang-ideExtension) config to `AgentGPT`. This enables developers and contributors to extract, access and update translations in code using the existing json files under the hood. 

- **Opt-in:** With the config in place you can also use the [fink editor](https://inlang.com/m/tdozzpar/app-inlang-editor) to update product copy/translation with a no code UI. Here u see an example from my fork: https://inlang.com/editor/github.com/NilsJacobsen/AgentGPT

# What I added (opt-in)
- A config file -> `settings.json`
- Vscode recommendation so the contributors can use the extension

## Screenshots:
IDE-Extension:
![image](https://github.com/StanGirard/quivr/assets/58360188/0dbcb63e-76d9-442e-8b00-cb1f5b28f03b)
![image](https://github.com/StanGirard/quivr/assets/58360188/dd50fe31-2445-4978-b9be-17ebb32995d9)

Editor:
<img width="1509" alt="image" src="https://github.com/reworkd/AgentGPT/assets/58360188/6a1b7b71-0cd9-4db9-a405-716a29d4e4d9">