### PR TITLE
docs: Fixes typo in the documentation about translations

### DIFF
--- a/docs/development/translations.mdx
+++ b/docs/development/translations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Translations"
-description: Guide to translaitng the language.
+description: Guide to translating the language.
 icon: "globe"
 ---
 


### PR DESCRIPTION
Hey there :wave:

I was going through your documentation and noticed a small typo on the Translation page!
This PR simply fixes it.

Any feedback is welcome!