### PR TITLE
Update OpenAI API key regular expression 

### DIFF
--- a/cli/src/questions/newEnvQuestions.js
+++ b/cli/src/questions/newEnvQuestions.js
@@ -12,7 +12,7 @@ export const newEnvQuestions = [
         validate: async(apikey) => {
             if(apikey === "") return true;
 
-            if(!isValidKey(apikey, /^sk-[a-zA-Z0-9]{48}$/)) {
+            if(!isValidKey(apikey, /^sk-[a-zA-Z0-9]/)) {
                 return validKeyErrorMessage
             }
 


### PR DESCRIPTION
https://github.com/reworkd/AgentGPT/pull/219 introduces the previous regular expression but as mentioned in issue current keys have 56 chars instead of 51. removing the length validation in case it changes again in the future. 