### PR TITLE
fix ERR_SOCKET_TIMEOUT by matching npm version

### DIFF
--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Node.js image as the base image
-FROM node:19-alpine
+FROM node:18-alpine
 
 ARG NODE_ENV
 


### PR DESCRIPTION
This PR should fix #786 

I encounter the same problem from #786, and I am using Mac with docker and local node version v18.20.2. I keep seeing `npm WARN EBADENGINE current: { node: 'v19.9.0', npm: '9.6.3' }` which I knew was not the one I have config on local. 

The root cause seem to be from node version definition here 
https://github.com/antigenius0910/AgentGPT/blob/main/next/package.json#L6

which conflict with frontend docker file base image definition 
https://github.com/antigenius0910/AgentGPT/blob/main/next/Dockerfile#L2

this combination will produce below error
```
> [frontend  5/10] RUN npm ci:
3.526 npm WARN EBADENGINE Unsupported engine {
3.526 npm WARN EBADENGINE   package: 'agent-gpt@1.0.0',
3.527 npm WARN EBADENGINE   required: { node: '>=18.0.0 <19.0.0' },
3.528 npm WARN EBADENGINE   current: { node: 'v19.9.0', npm: '9.6.3' }
3.529 npm WARN EBADENGINE }
26.91 npm notice
26.91 npm notice New major version of npm available! 9.6.3 -> 10.7.0
26.91 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.7.0>
26.91 npm notice Run `npm install -g npm@10.7.0` to update!
26.91 npm notice
26.92 npm ERR! code ERR_SOCKET_TIMEOUT
26.92 npm ERR! network Socket timeout
26.92 npm ERR! network This is a problem related to network connectivity.
26.92 npm ERR! network In most cases you are behind a proxy or have bad network settings.
26.92 npm ERR! network
26.92 npm ERR! network If you are behind a proxy, please make sure that the
26.92 npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
26.94
26.94 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2024-05-14T05_40_37_022Z-debug-0.log
------
failed to solve: process "/bin/sh -c npm ci" did not complete successfully: exit code: 1
```

simply change base image from `node:19-alpine` to `node:18-alpine` and ran `./setup.sh` once again and everything start up correctly this time

```
[+] Running 2/5
 ✔ Network agentgpt_default       Created                                                                                                  0.1s
 ✔ Volume "agentgpt_agentgpt_db"  Created                                                                                                  0.0s
 ⠦ Container frontend             Created                                                                                                  5.6s
 ⠦ Container agentgpt_db          Created                                                                                                  5.6s
 ⠼ Container platform             Created                                                                                                  5.4s

frontend     | https://nextjs.org/telemetry
frontend     |
frontend     |   ▲ Next.js 13.5.6
frontend     |   - Local:        http://localhost:3000
frontend     |   - Environments: .env
frontend     |
frontend     |  ✓ Ready in 2.8s
```

