### PR TITLE
fix: corrected regex to allow for 51, 95 and 164 character length OpenAI secret keys

### DIFF
--- a/cli/src/questions/newEnvQuestions.js
+++ b/cli/src/questions/newEnvQuestions.js
@@ -12,7 +12,7 @@ export const newEnvQuestions = [
         validate: async(apikey) => {
             if(apikey === "") return true;
 
-            if(!isValidKey(apikey, /^(?=(sk-(proj-)?[a-zA-Z0-9\-\_]*)$)(?:.{48}|.{95}|.{164})$/)) {
+            if(!isValidKey(apikey, /^(?=(sk-(proj-)?[a-zA-Z0-9\-\_]*)$)(?:.{51}|.{95}|.{164})$/)) {
                 return validKeyErrorMessage
             }
 

--- a/cli/src/questions/newEnvQuestions.js
+++ b/cli/src/questions/newEnvQuestions.js
@@ -12,7 +12,7 @@ export const newEnvQuestions = [
         validate: async(apikey) => {
             if(apikey === "") return true;
 
-            if(!isValidKey(apikey, /^sk-[a-zA-Z0-9]{48}$/)) {
+            if(!isValidKey(apikey, /^(?=(sk-(proj-)?[a-zA-Z0-9\-\_]*)$)(?:.{48}|.{95}|.{164})$/)) {
                 return validKeyErrorMessage
             }
 


### PR DESCRIPTION
Updated regex when creating a new environment to account for keys of different lengths.

Fixes #1624

Example tests:
![image](https://github.com/user-attachments/assets/a9845700-73b5-403c-8ebb-d94434f759a7)

